### PR TITLE
Upgrade handler for "Infra & Storage Deals"

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -141,7 +141,9 @@ import (
 
 	store "github.com/cosmos/cosmos-sdk/store/types"
 	v2 "github.com/jackalLabs/canine-chain/app/upgrades/v2"
+	v120alpha6 "github.com/jackalLabs/canine-chain/app/upgrades/v1.2.0-alpha.6"
 	v3 "github.com/jackalLabs/canine-chain/app/upgrades/v3"
+
 
 	// unnamed import of statik for swagger UI support
 	_ "github.com/cosmos/cosmos-sdk/client/docs/statik"
@@ -1062,6 +1064,15 @@ func (app *JackalApp) setupUpgradeHandlers() {
 		),
 	)
 
+	// version 1.2.0-alpha.6 upgrade keeper
+	app.upgradeKeeper.SetUpgradeHandler(
+		v120alpha6.UpgradeName,
+		v120alpha6.CreateUpgradeHandler(
+			app.mm,
+			app.configurator,
+		),
+	)
+
 	// version 3 upgrade keeper
 	app.upgradeKeeper.SetUpgradeHandler(
 		v3.UpgradeName,
@@ -1088,6 +1099,12 @@ func (app *JackalApp) setupUpgradeHandlers() {
 	if upgradeInfo.Name == v2.UpgradeName {
 		storeUpgrades = &store.StoreUpgrades{
 			Deleted: []string{"storage", "dsig", "notifications", "filetree"},
+		}
+	}
+
+	if upgradeInfo.Name == v120alpha6.UpgradeName {
+		storeUpgrades = &store.StoreUpgrades{
+			Added: []string{"storage"},
 		}
 	}
 

--- a/app/app.go
+++ b/app/app.go
@@ -1102,11 +1102,11 @@ func (app *JackalApp) setupUpgradeHandlers() {
 		}
 	}
 
-	if upgradeInfo.Name == v120alpha6.UpgradeName {
-		storeUpgrades = &store.StoreUpgrades{
-			Added: []string{"storage"},
-		}
-	}
+	// if upgradeInfo.Name == v120alpha6.UpgradeName {
+	// 	storeUpgrades = &store.StoreUpgrades{
+	// 		Added: []string{"storage"},
+	// 	}
+	// }
 
 	if upgradeInfo.Name == v3.UpgradeName {
 		storeUpgrades = &store.StoreUpgrades{

--- a/app/app.go
+++ b/app/app.go
@@ -1102,12 +1102,6 @@ func (app *JackalApp) setupUpgradeHandlers() {
 		}
 	}
 
-	// if upgradeInfo.Name == v120alpha6.UpgradeName {
-	// 	storeUpgrades = &store.StoreUpgrades{
-	// 		Added: []string{"storage"},
-	// 	}
-	// }
-
 	if upgradeInfo.Name == v3.UpgradeName {
 		storeUpgrades = &store.StoreUpgrades{
 			Added: []string{"storage"},

--- a/app/upgrades/v1.2.0-alpha.6/constant.go
+++ b/app/upgrades/v1.2.0-alpha.6/constant.go
@@ -1,0 +1,5 @@
+package v120alpha6
+
+const (
+	UpgradeName = "Infra & Storage Deals"
+)

--- a/app/upgrades/v1.2.0-alpha.6/upgrades.go
+++ b/app/upgrades/v1.2.0-alpha.6/upgrades.go
@@ -13,10 +13,6 @@ func CreateUpgradeHandler(
 	return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		logger := ctx.Logger().With("upgrade", UpgradeName)
 
-		// for _, moduleName := range []string{"storage"} {
-		// 	logger.Debug("adding module", moduleName, "to version map")
-		// }
-
 		logger.Debug("running module migrations")
 		return mm.RunMigrations(ctx, configurator, vm)
 	}

--- a/app/upgrades/v1.2.0-alpha.6/upgrades.go
+++ b/app/upgrades/v1.2.0-alpha.6/upgrades.go
@@ -13,9 +13,8 @@ func CreateUpgradeHandler(
 	return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		logger := ctx.Logger().With("upgrade", UpgradeName)
 
-		for _, moduleName := range []string{"storage", "dsig", "notifications", "filetreekeeper"} {
-			logger.Debug("removing module", moduleName, "from version map")
-			delete(vm, moduleName)
+		for _, moduleName := range []string{"storage"} {
+			logger.Debug("adding module", moduleName, "to version map")
 		}
 
 		logger.Debug("running module migrations")

--- a/app/upgrades/v1.2.0-alpha.6/upgrades.go
+++ b/app/upgrades/v1.2.0-alpha.6/upgrades.go
@@ -1,0 +1,24 @@
+package v120alpha6
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+)
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		logger := ctx.Logger().With("upgrade", UpgradeName)
+
+		for _, moduleName := range []string{"storage", "dsig", "notifications", "filetreekeeper"} {
+			logger.Debug("removing module", moduleName, "from version map")
+			delete(vm, moduleName)
+		}
+
+		logger.Debug("running module migrations")
+		return mm.RunMigrations(ctx, configurator, vm)
+	}
+}

--- a/app/upgrades/v1.2.0-alpha.6/upgrades.go
+++ b/app/upgrades/v1.2.0-alpha.6/upgrades.go
@@ -13,9 +13,9 @@ func CreateUpgradeHandler(
 	return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		logger := ctx.Logger().With("upgrade", UpgradeName)
 
-		for _, moduleName := range []string{"storage"} {
-			logger.Debug("adding module", moduleName, "to version map")
-		}
+		// for _, moduleName := range []string{"storage"} {
+		// 	logger.Debug("adding module", moduleName, "to version map")
+		// }
 
 		logger.Debug("running module migrations")
 		return mm.RunMigrations(ctx, configurator, vm)


### PR DESCRIPTION
Added upgrade handler for "Infra & Storage Deals" upgrade, since it was missing in alpha.5. Tested to be running and accepting the upgrade block.

Suggested new version: v1.2.0-alpha.6