### PR TITLE
enable benchmark simulation and fix upgrade script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ log.txt
 # Build
 vendor
 build
+_build
 tools/bin/*
 examples/build/*
 docs/_build

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ dependency-graph.png
 *.out
 *.synctex.gz
 contract_tests/*
+app.test

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ test-sim-multi-seed-short: runsim
 	@$(BINDIR)/runsim -Jobs=4 -SimAppPkg=$(SIMAPP) -ExitOnFail 50 10 TestFullAppSimulation
 
 test-sim-bench:
-	@VERSION=$(VERSION) go test -benchmem -run ^BenchmarkFullAppSimulation -bench ^BenchmarkFullAppSimulation -cpuprofile cpu.out github.com/jackalLabs/canine-chain/app -Commit=true
+	@VERSION=$(VERSION) go test -benchmem -run ^BenchmarkFullAppSimulation -bench ^BenchmarkFullAppSimulation -cpuprofile cpu.out github.com/jackalLabs/canine-chain/app
 
 ###############################################################################
 ###                                Linting                                  ###

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,9 @@ test-sim-multi-seed-short: runsim
 	@echo "Running short multi-seed application simulation. This may take awhile!"
 	@$(BINDIR)/runsim -Jobs=4 -SimAppPkg=$(SIMAPP) -ExitOnFail 50 10 TestFullAppSimulation
 
+test-sim-bench:
+	@VERSION=$(VERSION) go test -benchmem -run ^BenchmarkFullAppSimulation -bench ^BenchmarkFullAppSimulation -cpuprofile cpu.out github.com/jackalLabs/canine-chain/app -Commit=true
+
 ###############################################################################
 ###                                Linting                                  ###
 ###############################################################################

--- a/app/app.go
+++ b/app/app.go
@@ -574,7 +574,7 @@ func NewJackalApp(
 
 	// The last arguments can contain custom message handlers, and custom query handlers,
 	// if we want to allow any custom callbacks
-	supportedFeatures := "iterator,staking,stargate"
+	supportedFeatures := "iterator,staking,stargate,cosmwasm_1_1"
 	app.wasmKeeper = wasm.NewKeeper(
 		appCodec,
 		keys[wasm.StoreKey],
@@ -621,7 +621,7 @@ func NewJackalApp(
 		app.DsigKeeper = *dsigmodulekeeper.NewKeeper(
 			appCodec,
 			keys[dsigmoduletypes.StoreKey],
-			keys[dsigmoduletypes.MemStoreKey],
+			keys[dsigmoduletypes.MemStoreKey],wasm
 			app.getSubspace(dsigmoduletypes.ModuleName),
 
 			app.AccountKeeper,

--- a/app/sim_test.go
+++ b/app/sim_test.go
@@ -55,7 +55,9 @@ type StoreKeysPrefixes struct {
 
 // SetupSimulation wraps simapp.SetupSimulation in order to create any export directory if they do not exist yet
 func SetupSimulation(dirPrefix, dbName string) (simtypes.Config, dbm.DB, string, log.Logger, bool, error) {
+	simapp.FlagEnabledValue = true
 	config, db, dir, logger, skip, err := simapp.SetupSimulation(dirPrefix, dbName)
+	config.Commit = true
 	if err != nil {
 		return simtypes.Config{}, nil, "", nil, false, err
 	}
@@ -281,7 +283,6 @@ func TestFullAppSimulation(t *testing.T) {
 
 // if you want to start pprof graph: go tool pprof -http localhost:8080 cpu.out
 func BenchmarkFullAppSimulation(b *testing.B) {
-	simapp.FlagEnabledValue = true
 	config, db, dir, logger, _, err := SetupSimulation("leveldb-app-sim", "Simulation")
 	require.NoError(b, err, "simulation setup failed")
 

--- a/scripts/upgrade-test.sh
+++ b/scripts/upgrade-test.sh
@@ -1,62 +1,64 @@
 #!/bin/bash
 
 OLD_VERSION=1.1.2-hotfix
-UPGRADE_HEIGHT=20
+UPGRADE_HEIGHT=30
 HOME=mytestnet
 ROOT=$(pwd)
 DENOM=ujkl
 SOFTWARE_UPGRADE_NAME=v3
 
-GOMODCACHE=~/go/pkg/mod
+# underscore so that go tool will not take gocache into account
+mkdir -p _build/gocache
+export GOMODCACHE=$ROOT/_build/gocache
 
 # install old binary
-if ! command -v build/old/canined &> /dev/null
+if ! command -v _build/old/canined &> /dev/null
 then
-    mkdir -p build/old
-    wget -c "https://github.com/JackalLabs/canine-chain/archive/refs/tags/v${OLD_VERSION}.zip" -O build/v${OLD_VERSION}.zip
-    unzip build/v${OLD_VERSION}.zip -d build
-    cd ./build/canine-chain-${OLD_VERSION}
-    GOBIN="$ROOT/build/old" go install -mod=readonly ./...
+    mkdir -p _build/old
+    wget -c "https://github.com/JackalLabs/canine-chain/archive/refs/tags/v${OLD_VERSION}.zip" -O _build/v${OLD_VERSION}.zip
+    unzip _build/v${OLD_VERSION}.zip -d _build
+    cd ./_build/canine-chain-${OLD_VERSION}
+    GOBIN="$ROOT/_build/old" go install -mod=readonly ./...
     cd ../..
 fi
 
 # install new binary
-if ! command -v build/new/canined &> /dev/null
+if ! command -v _build/new/canined &> /dev/null
 then
-    GOBIN="$ROOT/build/new" go install -mod=readonly ./... 2> /dev/null
+    GOBIN="$ROOT/_build/new" go install -mod=readonly ./... 2> /dev/null
 fi
 
 # start old node
-screen -dmS node1 bash scripts/run-upgrade-node.sh build/old/canined $DENOM
+screen -dmS node1 bash scripts/run-upgrade-node.sh _build/old/canined $DENOM
 
 sleep 20
 
-./build/old/canined tx gov submit-proposal software-upgrade "$SOFTWARE_UPGRADE_NAME" --upgrade-height $UPGRADE_HEIGHT --upgrade-info "temp" --title "upgrade" --description "upgrade"  --from test1 --keyring-backend test --chain-id test --home $HOME -y
+./_build/old/canined tx gov submit-proposal software-upgrade "$SOFTWARE_UPGRADE_NAME" --upgrade-height $UPGRADE_HEIGHT --upgrade-info "temp" --title "upgrade" --description "upgrade"  --from test1 --keyring-backend test --chain-id test --home $HOME -y
 
 sleep 3
 
-./build/old/canined tx gov deposit 1 "20000000${DENOM}" --from test1 --keyring-backend test --chain-id test --home $HOME -y
+./_build/old/canined tx gov deposit 1 "20000000${DENOM}" --from test1 --keyring-backend test --chain-id test --home $HOME -y
 
 sleep 3
 
-./build/old/canined tx gov vote 1 yes --from test --keyring-backend test --chain-id test --home $HOME -y
+./_build/old/canined tx gov vote 1 yes --from test --keyring-backend test --chain-id test --home $HOME -y
 
 sleep 3
 
-./build/old/canined tx gov vote 1 yes --from test1 --keyring-backend test --chain-id test --home $HOME -y
+./_build/old/canined tx gov vote 1 yes --from test1 --keyring-backend test --chain-id test --home $HOME -y
 
 sleep 3
 
 # determine block_height to halt
 while true; do 
-    BLOCK_HEIGHT=$(./build/old/canined status | jq '.SyncInfo.latest_block_height' -r)
+    BLOCK_HEIGHT=$(./_build/old/canined status | jq '.SyncInfo.latest_block_height' -r)
     if [ $BLOCK_HEIGHT = "$UPGRADE_HEIGHT" ]; then
         # assuming running only 1 canined
         echo "BLOCK HEIGHT = $UPGRADE_HEIGHT REACHED, KILLING OLD ONE"
         pkill canined
         break
     else
-        ./build/old/canined q gov proposal 1 --output=json | jq ".status"
+        ./_build/old/canined q gov proposal 1 --output=json | jq ".status"
         echo "BLOCK_HEIGHT = $BLOCK_HEIGHT"
         sleep 10
     fi
@@ -64,4 +66,4 @@ done
 
 sleep 3
 
-./build/new/canined start --log_level debug --home $HOME
+./_build/new/canined start --log_level debug --home $HOME

--- a/scripts/upgrade-test.sh
+++ b/scripts/upgrade-test.sh
@@ -49,10 +49,11 @@ sleep 3
 
 # determine block_height to halt
 while true; do 
-    BLOCK_HEIGHT=$(./build/new/canined status | jq '.SyncInfo.latest_block_height' -r)
+    BLOCK_HEIGHT=$(./build/old/canined status | jq '.SyncInfo.latest_block_height' -r)
     if [ $BLOCK_HEIGHT = "$UPGRADE_HEIGHT" ]; then
         # assuming running only 1 canined
         echo "BLOCK HEIGHT = $UPGRADE_HEIGHT REACHED, KILLING OLD ONE"
+        pkill canined
         break
     else
         ./build/old/canined q gov proposal 1 --output=json | jq ".status"

--- a/x/jklmint/module_simulation.go
+++ b/x/jklmint/module_simulation.go
@@ -29,7 +29,9 @@ func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
 	for i, acc := range simState.Accounts {
 		accs[i] = acc.Address.String()
 	}
-	jklmintGenesis := types.GenesisState{}
+	jklmintGenesis := types.GenesisState{
+		Params: types.NewParams(sdk.DefaultBondDenom),
+	}
 	simState.GenState[types.ModuleName] = simState.Cdc.MustMarshalJSON(&jklmintGenesis)
 }
 


### PR DESCRIPTION
I want to enable benchmark simulation so that I can better debug the flow of Jackal app. It is much better to debug if you can visualize something like this:

<img width="1512" alt="Screenshot 2022-12-05 at 23 18 14" src="https://user-images.githubusercontent.com/23058164/205702606-21479249-7789-4e26-b9c2-d527657c2298.png">

According to that picture, there is an unknown process that takes up huge amount of processing time. Guess that it will need further debug.

During that process, I have fixed some simulation bugs also. There is 1 more I found for TestAppImportExport but it is not in the scope of this pr.

