### PR TITLE
oracle module unit tests progress update

### DIFF
--- a/x/oracle/keeper/msg_server_feeds_test.go
+++ b/x/oracle/keeper/msg_server_feeds_test.go
@@ -1,0 +1,78 @@
+package keeper_test
+
+import (
+	"github.com/jackalLabs/canine-chain/x/oracle/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+)
+
+func (suite *KeeperTestSuite) TestCreateFeed() {
+	genesisFeed := types.Feed{
+		Owner: suite.testAccs[0].String(),
+		Data:  "",
+		Name:  "conflict",
+	}
+
+	cases := map[string]struct {
+		creator   sdk.AccAddress
+		name      string
+		expErr    bool
+		expErrMsg string
+	}{
+		"create feed": {
+			creator: suite.testAccs[0],
+			name:    "foo",
+			expErr:  false,
+		},
+
+		"cannot overwrite feed": {
+			creator:   suite.testAccs[0],
+			name:      "conflict",
+			expErr:    true,
+			expErrMsg: "overwrite",
+		},
+
+		"not enough balance": {
+			creator:   suite.testAccs[1],
+			name:      "bar",
+			expErr:    true,
+			expErrMsg: "not enough balance",
+		},
+	}
+
+	for name, tc := range cases {
+		suite.Run(name, func() {
+			suite.SetupSuite()
+			msgSrvr, _, _ := setupMsgServer(suite)
+			suite.oracleKeeper.SetFeed(suite.ctx, genesisFeed)
+
+			// TODO: setup simulation and use that instead
+			// Fund account
+			coins := sdk.NewCoins(sdk.NewCoin("ujkl", sdk.NewInt(1000000000000)))
+			err := suite.bankKeeper.MintCoins(suite.ctx, minttypes.ModuleName, coins)
+			suite.NoError(err)
+			err = suite.bankKeeper.SendCoinsFromModuleToModule(suite.ctx, minttypes.ModuleName, types.ModuleName, coins)
+			suite.NoError(err)
+
+			coin := sdk.NewInt64Coin("ujkl", 100000000)
+			err = suite.bankKeeper.SendCoinsFromModuleToAccount(
+				suite.ctx,
+				types.ModuleName,
+				suite.testAccs[0],
+				sdk.NewCoins(coin))
+			suite.Require().NoError(err)
+
+			result, err := msgSrvr.CreateFeed(sdk.WrapSDKContext(suite.ctx), &types.MsgCreateFeed{
+				Creator: tc.creator.String(),
+				Name:    tc.name,
+			})
+
+			if tc.expErr {
+				suite.Require().Error(err)
+				suite.Require().Contains(err.Error(), tc.expErrMsg)
+				suite.Require().Nil(result)
+			}
+		})
+	}
+}

--- a/x/oracle/keeper/msg_server_feeds_test.go
+++ b/x/oracle/keeper/msg_server_feeds_test.go
@@ -76,3 +76,53 @@ func (suite *KeeperTestSuite) TestCreateFeed() {
 		})
 	}
 }
+
+func (suite *KeeperTestSuite) TestUpdateFeed() {
+	suite.SetupSuite()
+
+	genesisFeed := types.Feed{
+		Owner: suite.testAccs[0].String(),
+		Name:  "foo",
+	}
+
+	cases := map[string]struct {
+		creator sdk.AccAddress
+		name    string
+		expErr  bool
+	}{
+		"update feed": {
+			creator: suite.testAccs[0],
+			name:    "foo",
+			expErr:  false,
+		},
+		"cannot find feed": {
+			creator: suite.testAccs[0],
+			name:    "null",
+			expErr:  true,
+		},
+		"invalid owner": {
+			creator: suite.testAccs[1],
+			name:    "foo",
+			expErr:  true,
+		},
+	}
+
+	for name, tc := range cases {
+		suite.Run(name, func() {
+			suite.reset()
+			suite.oracleKeeper.SetFeed(suite.ctx, genesisFeed)
+			msgSrvr, _, wctx := setupMsgServer(suite)
+
+			result, err := msgSrvr.UpdateFeed(wctx, &types.MsgUpdateFeed{
+				Name:    tc.name,
+				Creator: tc.creator.String(),
+				Data:    "",
+			})
+
+			if !tc.expErr {
+				suite.Require().NoError(err)
+				suite.Require().NotNil(result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Added test accounts to [`KeeperTestSuite`](https://github.com/JackalLabs/canine-chain/blob/ece9b3700ad9b8f78cf533af52a2a8f71553a990/x/oracle/keeper/keeper_test.go#L29)
[`reset()`](https://github.com/JackalLabs/canine-chain/blob/ece9b3700ad9b8f78cf533af52a2a8f71553a990/x/oracle/keeper/keeper_test.go#L36) adds three test accounts to `KeeperTestSuite`
Added unit tests for [`CreateFeed()`](https://github.com/JackalLabs/canine-chain/blob/ece9b3700ad9b8f78cf533af52a2a8f71553a990/x/oracle/keeper/msg_server_feeds_test.go#L10) and [`UpdateFeed()`](https://github.com/JackalLabs/canine-chain/blob/ece9b3700ad9b8f78cf533af52a2a8f71553a990/x/oracle/keeper/msg_server_feeds_test.go#L80)