### PR TITLE
fix upgrade storage plan end date calculation and add upgrade-storage cli cmd

### DIFF
--- a/x/storage/client/cli/tx.go
+++ b/x/storage/client/cli/tx.go
@@ -29,7 +29,7 @@ func GetTxCmd() *cobra.Command {
 	cmd.AddCommand(CmdCancelContract())
 	cmd.AddCommand(CmdBuyStorage())
 	cmd.AddCommand(CmdClaimStray())
-	// this line is used by starport scaffolding # 1
+	cmd.AddCommand(CmdUpgradeStorage())
 
 	return cmd
 }

--- a/x/storage/client/cli/tx_upgrade_storage.go
+++ b/x/storage/client/cli/tx_upgrade_storage.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"strconv"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/jackalLabs/canine-chain/x/storage/types"
+	"github.com/spf13/cobra"
+)
+
+var _ = strconv.Itoa(0)
+
+func CmdUpgradeStorage() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "upgrade-storage [for-address] [duration] [bytes] [payment-denom]",
+		Short: "Broadcast message upgrade-storage",
+		Args:  cobra.ExactArgs(4),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			argForAddress := args[0]
+			argDuration := args[1]
+			argBytes := args[2]
+			argPaymentDenom := args[3]
+
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			msg := types.NewMsgUpgradeStorage(
+				clientCtx.GetFromAddress().String(),
+				argForAddress,
+				argDuration,
+				argBytes,
+				argPaymentDenom,
+			)
+			if err := msg.ValidateBasic(); err != nil {
+				return err
+			}
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/x/storage/keeper/msg_server_upgrade_storage.go
+++ b/x/storage/keeper/msg_server_upgrade_storage.go
@@ -47,7 +47,7 @@ func (k Keeper) UpgradeStorage(goCtx context.Context, msg *types.MsgUpgradeStora
 		return nil, fmt.Errorf("duration can't be parsed: %s", err.Error())
 	}
 
-	if duration <= 0 {
+	if duration.Truncate(timeMonth) <= 0 {
 		return nil, sdkerr.Wrap(sdkerr.ErrInvalidRequest, "duration can't be less than 1 month")
 	}
 
@@ -101,10 +101,9 @@ func (k Keeper) UpgradeStorage(goCtx context.Context, msg *types.MsgUpgradeStora
 		return nil, err
 	}
 
-	timeTotal := timeMonth * duration
 	spi := types.StoragePaymentInfo{
 		Start:          ctx.BlockTime(),
-		End:            ctx.BlockTime().Add(timeTotal),
+		End:            ctx.BlockTime().Add(duration),
 		SpaceAvailable: bytes,
 		SpaceUsed:      payInfo.SpaceUsed,
 		Address:        msg.ForAddress,

--- a/x/storage/simulation/upgrade_storage.go
+++ b/x/storage/simulation/upgrade_storage.go
@@ -38,7 +38,7 @@ func SimulateMsgUpgradeStorage(
 		}
 
 		oldSize := paymentInfo.SpaceAvailable
-		size := simtypes.RandIntBetween(r, int(oldSize), int(oldSize)+10_000_000_000)
+		size := simtypes.RandIntBetween(r, int(oldSize)+10_000_000_000, int(oldSize)+10_000_000_000_000)
 
 		t := time.Hour * 1440
 		hours := sdk.NewDec(t.Milliseconds()).Quo(sdk.NewDec(60 * 60 * 1000))


### PR DESCRIPTION
There is a miscalculation in storage plan end date. [canine-chain/msg_server_upgrade_storage.go at a39271478a28f936e1c787a736532c89ffe31671 · JackalLabs/canine-chain](https://github.com/JackalLabs/canine-chain/blob/a39271478a28f936e1c787a736532c89ffe31671/x/storage/keeper/msg_server_upgrade_storage.go#L104) 

Month time of type time.Time multiplied with upgrade duration of type time.Duration large enough (like a month) will create integer overflow and result in end date being earlier than current time.

The fix removes timeMonth * timeDuration and End date is calculated as ctx.BlockTime().Add(duration).