### PR TITLE
add current usage check to storage upgrade tx

### DIFF
--- a/x/storage/keeper/msg_server_upgrade_storage.go
+++ b/x/storage/keeper/msg_server_upgrade_storage.go
@@ -61,6 +61,10 @@ func (k Keeper) UpgradeStorage(goCtx context.Context, msg *types.MsgUpgradeStora
 		return nil, sdkerr.Wrap(sdkerr.ErrInvalidRequest, "cannot buy less than a gb")
 	}
 
+	if newBytes < payInfo.SpaceUsed {
+		return nil, sdkerr.Wrap(sdkerr.ErrInvalidRequest, "cannot downgrade below current usage")
+	}
+
 	hours := sdk.NewDec(duration.Milliseconds()).Quo(sdk.NewDec(60 * 60 * 1000))
 	newCost := k.GetStorageCost(ctx, newGbs, hours.TruncateInt64())
 


### PR DESCRIPTION
Added changes to upgrade storage tx.
Upgrade bytes needs to be bigger than current space used.
If the [condition (newBytes < spaceUsed)](https://github.com/JackalLabs/canine-chain/blob/d3f0309e7fd11e3f91cc9e0eaa5da4c3d4118b7c/x/storage/keeper/msg_server_upgrade_storage.go#L64) is true, invalid request error with "cannot downgrade below current usage" is returned.