### PR TITLE
Adding auto-testnet scripts

### DIFF
--- a/scripts/auto-testnet/ValidatorDockerfile
+++ b/scripts/auto-testnet/ValidatorDockerfile
@@ -1,0 +1,33 @@
+FROM golang:1.20
+# validator build script
+
+# creating new working dir in the container
+WORKDIR /home/canine-validator
+
+RUN apt-get update
+
+# installing git
+RUN apt-get install git jq net-tools -y
+
+# cloning the release version
+ARG RELEASE
+RUN git clone -b ${RELEASE} https://github.com/JackalLabs/canine-chain.git /home/canine-validator
+
+# installing the canine chain
+RUN make install
+# installing the canine binary
+RUN go install /home/canine-validator/cmd/canined
+
+ARG VALIDATOR_SCRIPT=validator.sh
+# copying the genesis setup script 
+COPY ${VALIDATOR_SCRIPT} /home/canine-validator/scripts
+RUN chmod +x /home/canine-validator/scripts/${VALIDATOR_SCRIPT}
+# copying the regular validator script
+COPY validator.sh /home/canine-validator/scripts
+RUN chmod +x /home/canine-validator/scripts/validator.sh
+
+# keeping the container as an executable
+CMD ["tail", "-f", "/dev/null" ]
+
+# exposing ports for canine
+EXPOSE 26657 26656 26658 1317 6060 9090

--- a/scripts/auto-testnet/genesis-validator.sh
+++ b/scripts/auto-testnet/genesis-validator.sh
@@ -39,18 +39,6 @@ canined gentx $VALIDATOR_NAME 500000000ujkl \
 --commission-rate=0.05 \
 --keyring-backend=test \
 
-# canined gentx $VALIDATOR_NAME 500000000ujkl \
-# --keyring-backend=test \
-# --chain-id=$CHAIN_ID \
-# --moniker=$VALIDATOR_NAME \
-# --commission-max-change-rate=0.01 \
-# --commission-max-rate=0.20 \
-# --commission-rate=0.05 \
-# --account-number=$ACCOUNT_NUMBER \
-# --fees=2500ujkl \
-# --from=$VALIDATOR_NAME \
-# --keyring-backend=test \
-
 # update staking genesis
 cat $HOME/.canine/config/genesis.json | jq '.app_state["staking"]["params"]["bond_denom"]="ujkl"' > $HOME/.canine/config/tmp_genesis.json && mv $HOME/.canine/config/tmp_genesis.json $HOME/.canine/config/genesis.json
 cat $HOME/.canine/config/genesis.json | jq '.app_state["staking"]["params"]["unbonding_time"]="240s"' > $HOME/.canine/config/tmp_genesis.json && mv $HOME/.canine/config/tmp_genesis.json $HOME/.canine/config/genesis.json

--- a/scripts/auto-testnet/genesis-validator.sh
+++ b/scripts/auto-testnet/genesis-validator.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -e
+
+# collecting keywords
+# required keywords: VALIDATOR_NAME,  CHAIN_ID, 
+for ARGUMENT in "$@"
+do
+   KEY=$(echo $ARGUMENT | cut -f1 -d=)
+
+   KEY_LENGTH=${#KEY}
+   VALUE="${ARGUMENT:$KEY_LENGTH+1}"
+
+   export "$KEY"="$VALUE"
+done
+
+# removing all older jackal inits (if they exist)
+rm -rf $HOME/.canine
+
+# making a new jackal directory
+mkdir $HOME/.canine
+
+# initializing the validator 
+canined init $VALIDATOR_NAME --chain-id=$CHAIN_ID  --home=$HOME/.canine
+
+# creating new keys
+canined keys add $VALIDATOR_NAME --keyring-backend=test --home=$HOME/.canine
+
+# create validator node with tokens to transfer to the three other nodes
+canined add-genesis-account $(canined keys show $VALIDATOR_NAME -a --keyring-backend=test --home=$HOME/.canine) \
+2000000000ujkl --home=$HOME/.canine 
+
+# creating a new gentx
+canined gentx $VALIDATOR_NAME 500000000ujkl \
+--chain-id=testing \
+--pubkey=$(canined tendermint show-validator --chain-id=testing) \
+--fees=2500ujkl \
+--commission-max-change-rate=0.01 \
+--commission-max-rate=0.20 \
+--commission-rate=0.05 \
+--keyring-backend=test \
+
+# canined gentx $VALIDATOR_NAME 500000000ujkl \
+# --keyring-backend=test \
+# --chain-id=$CHAIN_ID \
+# --moniker=$VALIDATOR_NAME \
+# --commission-max-change-rate=0.01 \
+# --commission-max-rate=0.20 \
+# --commission-rate=0.05 \
+# --account-number=$ACCOUNT_NUMBER \
+# --fees=2500ujkl \
+# --from=$VALIDATOR_NAME \
+# --keyring-backend=test \
+
+# update staking genesis
+cat $HOME/.canine/config/genesis.json | jq '.app_state["staking"]["params"]["bond_denom"]="ujkl"' > $HOME/.canine/config/tmp_genesis.json && mv $HOME/.canine/config/tmp_genesis.json $HOME/.canine/config/genesis.json
+cat $HOME/.canine/config/genesis.json | jq '.app_state["staking"]["params"]["unbonding_time"]="240s"' > $HOME/.canine/config/tmp_genesis.json && mv $HOME/.canine/config/tmp_genesis.json $HOME/.canine/config/genesis.json
+
+# update crisis variable to ujkl
+cat $HOME/.canine/config/genesis.json | jq '.app_state["crisis"]["constant_fee"]["denom"]="ujkl"' > $HOME/.canine/config/tmp_genesis.json && mv $HOME/.canine/config/tmp_genesis.json $HOME/.canine/config/genesis.json
+
+# update gov genesis
+cat $HOME/.canine/config/genesis.json | jq '.app_state["gov"]["voting_params"]["voting_period"]="60s"' > $HOME/.canine/config/tmp_genesis.json && mv $HOME/.canine/config/tmp_genesis.json $HOME/.canine/config/genesis.json
+cat $HOME/.canine/config/genesis.json | jq '.app_state["gov"]["deposit_params"]["min_deposit"][0]["denom"]="ujkl"' > $HOME/.canine/config/tmp_genesis.json && mv $HOME/.canine/config/tmp_genesis.json $HOME/.canine/config/genesis.json
+
+# update mint genesis
+cat $HOME/.canine/config/genesis.json | jq '.app_state["jklmint"]["params"]["mintDenom"]="ujkl"' > $HOME/.canine/config/tmp_genesis.json && mv $HOME/.canine/config/tmp_genesis.json $HOME/.canine/config/genesis.json
+
+# copying the genesis file to the common store
+cp /root/.canine/config/genesis.json /home/common_store/genesis.json
+
+# copying gentx to the common store
+cp -RT /root/.canine/config/gentx /home/common_store/gentx

--- a/scripts/auto-testnet/init-subnet.sh
+++ b/scripts/auto-testnet/init-subnet.sh
@@ -70,33 +70,3 @@ for i in {1..3}
 do
     docker exec -d validator_${i} canined start 
 done
-
-# # creating a new validator
-# docker exec genesis-validator canined tx staking create-validator \
-# --amount=400000000ujkl \
-# --pubkey=$(docker exec genesis-validator canined tendermint show-validator --chain-id=testing) \
-# --moniker=genesis-val \
-# --chain-id=testing \
-# --commission-rate="0.10" \
-# --commission-max-rate="0.20" \
-# --commission-max-change-rate="0.05" \
-# --min-self-delegation="1" \
-# --from=genesis-val
-# --keyring-backend=test \
-# --yes 
-
-# for i in {1..3}
-# do
-#     # creating a new validator
-#     docker exec validator_${i} canined tx staking create-validator --amount=400000000ujkl \
-#     --from=val_${i} \
-#     --pubkey=$(docker exec validator_${i} canined tendermint show-validator --chain-id=testing) \
-#     --moniker=val_${i} \
-#     --chain-id=$CHAIN_ID \
-#     --commission-rate="0.1" \
-#     --commission-max-rate="0.2" \
-#     --commission-max-change-rate="0.05" \
-#     --min-self-delegation="1" \
-#     --keyring-backend=test \
-#     --yes 
-# done

--- a/scripts/auto-testnet/init-subnet.sh
+++ b/scripts/auto-testnet/init-subnet.sh
@@ -1,13 +1,24 @@
 #!/bin/bash
-set -x
+set -e
+
+# collecting keywords
+# required keywords: NUM_VALIDATORS, RELEASE, CHAIN_ID,  
+for ARGUMENT in "$@"
+do
+   KEY=$(echo $ARGUMENT | cut -f1 -d=)
+
+   KEY_LENGTH=${#KEY}
+   VALUE="${ARGUMENT:$KEY_LENGTH+1}"
+
+   export "$KEY"="$VALUE"
+done
 
 # building the validator docker image
 docker buildx build . -t validator \
 -f ValidatorDockerfile \
---build-arg RELEASE=v1.2.1 \
+--build-arg RELEASE=$RELEASE \
 --build-arg VALIDATOR_SCRIPT=genesis-validator.sh \
---build-arg CHAIN_ID=testing \
---build-arg VALIDATOR_NAME=genesis-val \
+--build-arg CHAIN_ID=$CHAIN_ID
 
 # running the docker image
 sudo docker run -d -v "/root/common_store:/home/common_store" \
@@ -17,10 +28,10 @@ validator
 # executing internal scripts
 sudo docker exec genesis-validator bash /home/canine-validator/scripts/genesis-validator.sh \
 VALIDATOR_NAME=genesis-val \
-CHAIN_ID=testing
+CHAIN_ID=$CHAIN_ID
 
 # spawning additional docker images, w/o the genesis validator
-for i in {1..3}
+for ((i=1; i <= $NUM_VALIDATORS-1; i++));
 do
     # running the docker image
     docker run -d -v "/root/common_store:/home/common_store" \
@@ -30,7 +41,7 @@ do
     # executing internal scripts
     docker exec validator_${i} bash /home/canine-validator/scripts/validator.sh \
     VALIDATOR_NAME=val_${i} \
-    CHAIN_ID=testing \
+    CHAIN_ID=$CHAIN_ID \
 
 done
 
@@ -38,8 +49,8 @@ done
 # docker exec genesis-validator rm -rf /root/.canine/config/gentx
 docker exec genesis-validator cp /home/common_store/genesis.json /root/.canine/config/genesis.json
 docker exec genesis-validator cp -RT /home/common_store/gentx /root/.canine/config/gentx
-docker exec genesis-validator canined collect-gentxs --chain-id=testing
-docker exec genesis-validator canined tendermint unsafe-reset-all --chain-id=testing 
+docker exec genesis-validator canined collect-gentxs --chain-id=$CHAIN_ID
+docker exec genesis-validator canined tendermint unsafe-reset-all --chain-id=$CHAIN_ID 
 
 # changing the genesis-validator listening address in config.toml
 export IPADDR=$(docker exec genesis-validator hostname -I | tr -d ' ')
@@ -47,14 +58,14 @@ docker exec genesis-validator sed -i "s|tcp://0\.0\.0\.0:26656|tcp://$IPADDR:266
 docker exec genesis-validator sed -i "s|tcp://127\.0\.0\.1:26657|tcp://$IPADDR:26657|" $HOME/.canine/config/config.toml
 docker exec genesis-validator sed -i "s|tcp://127\.0\.0\.1:26658|tcp://$IPADDR:26658|" $HOME/.canine/config/config.toml
 
-for i in {1..3}
+for ((i=1; i <= $NUM_VALIDATORS-1; i++));
 do
     # collecting the gentxs
     # docker exec validator_${i} rm -rf /root/.canine/config/gentx
     docker exec validator_${i} cp /home/common_store/genesis.json /root/.canine/config/genesis.json
     docker exec validator_${i} cp -RT /home/common_store/gentx /root/.canine/config/gentx
-    docker exec validator_${i} canined collect-gentxs --chain-id=testing
-    docker exec validator_${i} canined tendermint unsafe-reset-all --chain-id=testing 
+    docker exec validator_${i} canined collect-gentxs --chain-id=$CHAIN_ID
+    docker exec validator_${i} canined tendermint unsafe-reset-all --chain-id=$CHAIN_ID 
 
     # changing the genesis-validator listening address in config.toml
     export IPADDR=$(docker exec validator_${i} hostname -I | tr -d ' ')
@@ -65,8 +76,7 @@ done
 
 # starting the chain 
 docker exec -d genesis-validator canined start
-
-for i in {1..3}
+for ((i=1; i <= $NUM_VALIDATORS-1; i++));
 do
     docker exec -d validator_${i} canined start 
 done

--- a/scripts/auto-testnet/init-subnet.sh
+++ b/scripts/auto-testnet/init-subnet.sh
@@ -45,8 +45,10 @@ docker exec genesis-validator canined tendermint unsafe-reset-all --chain-id=tes
 export IPADDR=$(docker exec genesis-validator hostname -I | tr -d ' ')
 docker exec genesis-validator sed -i "s|tcp://0\.0\.0\.0:26656|tcp://$IPADDR:26656|" $HOME/.canine/config/config.toml
 docker exec genesis-validator sed -i "s|tcp://127\.0\.0\.1:26657|tcp://$IPADDR:26657|" $HOME/.canine/config/config.toml
+docker exec genesis-validator sed -i "s|tcp://127\.0\.0\.1:26658|tcp://$IPADDR:26658|" $HOME/.canine/config/config.toml
 
 for i in {1..3}
+do
     # collecting the gentxs
     # docker exec validator_${i} rm -rf /root/.canine/config/gentx
     docker exec validator_${i} cp /home/common_store/genesis.json /root/.canine/config/genesis.json
@@ -58,6 +60,7 @@ for i in {1..3}
     export IPADDR=$(docker exec validator_${i} hostname -I | tr -d ' ')
     docker exec validator_${i} sed -i "s|tcp://0\.0\.0\.0:26656|tcp://$IPADDR:26656|" $HOME/.canine/config/config.toml
     docker exec validator_${i} sed -i "s|tcp://127\.0\.0\.1:26657|tcp://$IPADDR:26657|" $HOME/.canine/config/config.toml
+    docker exec validator_${i} sed -i "s|tcp://127\.0\.0\.1:26658|tcp://$IPADDR:26658|" $HOME/.canine/config/config.toml
 done
 
 # starting the chain 

--- a/scripts/auto-testnet/init-subnet.sh
+++ b/scripts/auto-testnet/init-subnet.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+set -x
+
+# building the validator docker image
+docker buildx build . -t validator \
+-f ValidatorDockerfile \
+--build-arg RELEASE=v1.2.1 \
+--build-arg VALIDATOR_SCRIPT=genesis-validator.sh \
+--build-arg CHAIN_ID=testing \
+--build-arg VALIDATOR_NAME=genesis-val \
+
+# running the docker image
+sudo docker run -d -v "/root/common_store:/home/common_store" \
+--name=genesis-validator \
+validator
+
+# executing internal scripts
+sudo docker exec genesis-validator bash /home/canine-validator/scripts/genesis-validator.sh \
+VALIDATOR_NAME=genesis-val \
+CHAIN_ID=testing
+
+# spawning additional docker images, w/o the genesis validator
+for i in {1..3}
+do
+    # running the docker image
+    docker run -d -v "/root/common_store:/home/common_store" \
+    --name=validator_${i} \
+    validator
+
+    # executing internal scripts
+    docker exec validator_${i} bash /home/canine-validator/scripts/validator.sh \
+    VALIDATOR_NAME=val_${i} \
+    CHAIN_ID=testing \
+
+done
+
+# collecting the genesis_validator gentx
+# docker exec genesis-validator rm -rf /root/.canine/config/gentx
+docker exec genesis-validator cp /home/common_store/genesis.json /root/.canine/config/genesis.json
+docker exec genesis-validator cp -RT /home/common_store/gentx /root/.canine/config/gentx
+docker exec genesis-validator canined collect-gentxs --chain-id=testing
+docker exec genesis-validator canined tendermint unsafe-reset-all --chain-id=testing 
+
+# changing the genesis-validator listening address in config.toml
+export IPADDR=$(docker exec genesis-validator hostname -I | tr -d ' ')
+docker exec genesis-validator sed -i "s|tcp://0\.0\.0\.0:26656|tcp://$IPADDR:26656|" $HOME/.canine/config/config.toml
+docker exec genesis-validator sed -i "s|tcp://127\.0\.0\.1:26657|tcp://$IPADDR:26657|" $HOME/.canine/config/config.toml
+
+for i in {1..3}
+    # collecting the gentxs
+    # docker exec validator_${i} rm -rf /root/.canine/config/gentx
+    docker exec validator_${i} cp /home/common_store/genesis.json /root/.canine/config/genesis.json
+    docker exec validator_${i} cp -RT /home/common_store/gentx /root/.canine/config/gentx
+    docker exec validator_${i} canined collect-gentxs --chain-id=testing
+    docker exec validator_${i} canined tendermint unsafe-reset-all --chain-id=testing 
+
+    # changing the genesis-validator listening address in config.toml
+    export IPADDR=$(docker exec validator_${i} hostname -I | tr -d ' ')
+    docker exec validator_${i} sed -i "s|tcp://0\.0\.0\.0:26656|tcp://$IPADDR:26656|" $HOME/.canine/config/config.toml
+    docker exec validator_${i} sed -i "s|tcp://127\.0\.0\.1:26657|tcp://$IPADDR:26657|" $HOME/.canine/config/config.toml
+done
+
+# starting the chain 
+docker exec -d genesis-validator canined start
+
+for i in {1..3}
+do
+    docker exec -d validator_${i} canined start 
+done
+
+# # creating a new validator
+# docker exec genesis-validator canined tx staking create-validator \
+# --amount=400000000ujkl \
+# --pubkey=$(docker exec genesis-validator canined tendermint show-validator --chain-id=testing) \
+# --moniker=genesis-val \
+# --chain-id=testing \
+# --commission-rate="0.10" \
+# --commission-max-rate="0.20" \
+# --commission-max-change-rate="0.05" \
+# --min-self-delegation="1" \
+# --from=genesis-val
+# --keyring-backend=test \
+# --yes 
+
+# for i in {1..3}
+# do
+#     # creating a new validator
+#     docker exec validator_${i} canined tx staking create-validator --amount=400000000ujkl \
+#     --from=val_${i} \
+#     --pubkey=$(docker exec validator_${i} canined tendermint show-validator --chain-id=testing) \
+#     --moniker=val_${i} \
+#     --chain-id=$CHAIN_ID \
+#     --commission-rate="0.1" \
+#     --commission-max-rate="0.2" \
+#     --commission-max-change-rate="0.05" \
+#     --min-self-delegation="1" \
+#     --keyring-backend=test \
+#     --yes 
+# done

--- a/scripts/auto-testnet/validator.sh
+++ b/scripts/auto-testnet/validator.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+set -e
 
 # collecting keywords
 # required keywords: VALIDATOR_NAME,  CHAIN_ID, 

--- a/scripts/auto-testnet/validator.sh
+++ b/scripts/auto-testnet/validator.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -x
+
+# collecting keywords
+# required keywords: VALIDATOR_NAME,  CHAIN_ID, 
+for ARGUMENT in "$@"
+do
+   KEY=$(echo $ARGUMENT | cut -f1 -d=)
+
+   KEY_LENGTH=${#KEY}
+   VALUE="${ARGUMENT:$KEY_LENGTH+1}"
+
+   export "$KEY"="$VALUE"
+done
+
+echo "$@"
+
+# removing all older jackal inits (if they exist)
+rm -rf $HOME/.canine
+
+# making a new jackal directory
+mkdir $HOME/.canine
+
+# initializing the validator 
+canined init $VALIDATOR_NAME --chain-id=$CHAIN_ID 
+
+# copying the genesis
+cp /home/common_store/genesis.json /root/.canine/config/genesis.json
+
+# creating new keys
+canined keys add $VALIDATOR_NAME --keyring-backend=test
+
+# adding a genesis account 
+canined add-genesis-account \
+$(canined keys show $VALIDATOR_NAME -a --keyring-backend=test) \
+2000000000ujkl
+
+# creating the gentx
+canined gentx $VALIDATOR_NAME 500000000ujkl \
+--chain-id=testing \
+--pubkey=$(canined tendermint show-validator --chain-id=testing) \
+--fees=2500ujkl \
+--commission-max-change-rate=0.01 \
+--commission-max-rate=0.20 \
+--commission-rate=0.05 \
+--keyring-backend test \
+# canined gentx $VALIDATOR_NAME 500000000ujkl \
+# --keyring-backend=test \
+# --chain-id=$CHAIN_ID \
+# --account-number=$ACCOUNT_NUMBER
+# --moniker=$VALIDATOR_NAME \
+# --commission-max-change-rate=0.01 \
+# --commission-max-rate=0.20 \
+# --commission-rate=0.05 \
+# --fees=2500ujkl \
+# --from=$VALIDATOR_NAME \
+# --keyring-backend=test \
+
+# # copying the keys to the common store 
+# mkdir /home/common_store/keys 
+# canined keys export --keyring-backend=test
+
+# copying the modified genesis back
+cp /root/.canine/config/genesis.json /home/common_store/genesis.json
+
+# copying the gentxs
+cp -RT /root/.canine/config/gentx /home/common_store/gentx

--- a/scripts/auto-testnet/validator.sh
+++ b/scripts/auto-testnet/validator.sh
@@ -44,21 +44,6 @@ canined gentx $VALIDATOR_NAME 500000000ujkl \
 --commission-max-rate=0.20 \
 --commission-rate=0.05 \
 --keyring-backend test \
-# canined gentx $VALIDATOR_NAME 500000000ujkl \
-# --keyring-backend=test \
-# --chain-id=$CHAIN_ID \
-# --account-number=$ACCOUNT_NUMBER
-# --moniker=$VALIDATOR_NAME \
-# --commission-max-change-rate=0.01 \
-# --commission-max-rate=0.20 \
-# --commission-rate=0.05 \
-# --fees=2500ujkl \
-# --from=$VALIDATOR_NAME \
-# --keyring-backend=test \
-
-# # copying the keys to the common store 
-# mkdir /home/common_store/keys 
-# canined keys export --keyring-backend=test
 
 # copying the modified genesis back
 cp /root/.canine/config/genesis.json /home/common_store/genesis.json

--- a/scripts/auto-testnet/wipe.sh
+++ b/scripts/auto-testnet/wipe.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e 
+
+docker rm -f $(docker ps -a -q)
+docker rmi $(docker images -a -q) -f
+
+rm -rf /root/common_store/genesis.json /root/common_store/gentx


### PR DESCRIPTION
Specify the canine-chain release version, chain ID, and the total number of validators needed for the testnet. 

The script then builds the canine-chain and performs all of the genesis configurations and transactions necessary to start producing blocks. All the validators are spawned on the local computer and are connected to each other through the default 'bridge' docker network.

The current validator set can be accessed by running the following command inside any of the running containers:

`curl -s <hostname IP>:26657/validators` 

Where `<hostname IP>` can be found by executing `hostname -I` inside the running container.  