### PR TITLE
Feat: Recovery upgrade handler

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/jackalLabs/canine-chain/app/upgrades"
+	"github.com/jackalLabs/canine-chain/app/upgrades/recovery"
 	v121 "github.com/jackalLabs/canine-chain/app/upgrades/testnet/121"
 	"github.com/jackalLabs/canine-chain/app/upgrades/testnet/alpha11"
 	"github.com/jackalLabs/canine-chain/app/upgrades/testnet/alpha13"
@@ -1146,10 +1147,12 @@ func (app *JackalApp) registerTestnetUpgradeHandlers() {
 	app.registerUpgrade(beta6.NewUpgrade(app.mm, app.configurator, app.StorageKeeper))
 	app.registerUpgrade(beta7.NewUpgrade(app.mm, app.configurator, app.NotificationsKeeper))
 	app.registerUpgrade(v121.NewUpgrade(app.mm, app.configurator))
+	app.registerUpgrade(recovery.NewUpgrade(app.mm, app.configurator, app.StorageKeeper))
 }
 
 func (app *JackalApp) registerMainnetUpgradeHandlers() {
 	app.registerUpgrade(bouncybulldog.NewUpgrade(app.mm, app.configurator, app.OracleKeeper))
+	app.registerUpgrade(recovery.NewUpgrade(app.mm, app.configurator, app.StorageKeeper))
 }
 
 // registerUpgrade registers the given upgrade to be supported by the app

--- a/app/upgrades/recovery/upgrades.go
+++ b/app/upgrades/recovery/upgrades.go
@@ -35,24 +35,7 @@ func (u *Upgrade) Name() string {
 // Handler implements upgrades.Upgrade
 func (u *Upgrade) Handler() upgradetypes.UpgradeHandler {
 	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
-		strays := u.storageKeeper.GetAllStrays(ctx)
-		deals := u.storageKeeper.GetAllActiveDeals(ctx)
-
-		for _, stray := range strays {
-			found := false
-			for _, deal := range deals {
-				if stray.Fid == deal.Fid {
-					found = true
-					break
-				}
-			}
-			if found {
-				continue
-			}
-
-			u.storageKeeper.RemoveStrays(ctx, stray.Cid)
-		}
-
+		u.storageKeeper.ClearDeadFiles(ctx)
 		return fromVM, nil
 	}
 }

--- a/app/upgrades/recovery/upgrades.go
+++ b/app/upgrades/recovery/upgrades.go
@@ -1,0 +1,63 @@
+package recovery
+
+import (
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	"github.com/jackalLabs/canine-chain/app/upgrades"
+	storagekeeper "github.com/jackalLabs/canine-chain/x/storage/keeper"
+)
+
+var _ upgrades.Upgrade = &Upgrade{}
+
+// Upgrade represents the v4 upgrade
+type Upgrade struct {
+	mm            *module.Manager
+	configurator  module.Configurator
+	storageKeeper storagekeeper.Keeper
+}
+
+// NewUpgrade returns a new Upgrade instance
+func NewUpgrade(mm *module.Manager, configurator module.Configurator, storageKeeper storagekeeper.Keeper) *Upgrade {
+	return &Upgrade{
+		mm:            mm,
+		configurator:  configurator,
+		storageKeeper: storageKeeper,
+	}
+}
+
+// Name implements upgrades.Upgrade
+func (u *Upgrade) Name() string {
+	return "recovery"
+}
+
+// Handler implements upgrades.Upgrade
+func (u *Upgrade) Handler() upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		strays := u.storageKeeper.GetAllStrays(ctx)
+		deals := u.storageKeeper.GetAllActiveDeals(ctx)
+
+		for _, stray := range strays {
+			found := false
+			for _, deal := range deals {
+				if stray.Fid == deal.Fid {
+					found = true
+					break
+				}
+			}
+			if found {
+				continue
+			}
+
+			u.storageKeeper.RemoveStrays(ctx, stray.Cid)
+		}
+
+		return fromVM, nil
+	}
+}
+
+// StoreUpgrades implements upgrades.Upgrade
+func (u *Upgrade) StoreUpgrades() *storetypes.StoreUpgrades {
+	return &storetypes.StoreUpgrades{}
+}

--- a/scripts/run-upgrade-node.sh
+++ b/scripts/run-upgrade-node.sh
@@ -37,6 +37,7 @@ update_test_genesis '.app_state["crisis"]["constant_fee"]={"denom": $DENOM,"amou
 update_test_genesis '.app_state["staking"]["params"]["bond_denom"]=$DENOM' $DENOM
 update_test_genesis '.app_state["storage"]["params"]["misses_to_burn"]=2' $DENOM
 update_test_genesis '.app_state["storage"]["params"]["proof_window"]=3' $DENOM
+update_test_genesis '.app_state["storage"]["params"]["deposit_account:"]=jkl12g4qwenvpzqeakavx5adqkw203s629tf6k8vdg' $DENOM
 
 
 sed -i '' 's/enable = false/enable = true/' $HOME/config/app.toml

--- a/scripts/run-upgrade-node.sh
+++ b/scripts/run-upgrade-node.sh
@@ -37,7 +37,7 @@ update_test_genesis '.app_state["crisis"]["constant_fee"]={"denom": $DENOM,"amou
 update_test_genesis '.app_state["staking"]["params"]["bond_denom"]=$DENOM' $DENOM
 update_test_genesis '.app_state["storage"]["params"]["misses_to_burn"]=2' $DENOM
 update_test_genesis '.app_state["storage"]["params"]["proof_window"]=3' $DENOM
-update_test_genesis '.app_state["storage"]["params"]["deposit_account"]=jkl12g4qwenvpzqeakavx5adqkw203s629tf6k8vdg' $DENOM
+update_test_genesis '.app_state["storage"]["params"]["deposit_account"]="jkl12g4qwenvpzqeakavx5adqkw203s629tf6k8vdg"' $DENOM
 
 
 sed -i '' 's/enable = false/enable = true/' $HOME/config/app.toml

--- a/scripts/run-upgrade-node.sh
+++ b/scripts/run-upgrade-node.sh
@@ -9,7 +9,7 @@ CHAIN_ID="test"
 KEYRING="test"
 KEY="test"
 KEY1="test1"
-KEY1="test2"
+KEY2="test2"
 
 # Function updates the config based on a jq argument as a string
 update_test_genesis () {

--- a/scripts/run-upgrade-node.sh
+++ b/scripts/run-upgrade-node.sh
@@ -9,6 +9,7 @@ CHAIN_ID="test"
 KEYRING="test"
 KEY="test"
 KEY1="test1"
+KEY1="test2"
 
 # Function updates the config based on a jq argument as a string
 update_test_genesis () {
@@ -21,17 +22,21 @@ $BINARY init --chain-id $CHAIN_ID moniker --home $HOME
 $BINARY keys add $KEY --keyring-backend $KEYRING --home $HOME
 
 echo "brief enhance flee chest rabbit matter chaos clever lady enable luggage arrange hint quarter change float embark canoe chalk husband legal dignity music web" | $BINARY keys add $KEY1 --keyring-backend $KEYRING --recover --home $HOME
+echo "bulk whisper now clump write donor jump menu option muffin crack absent angle dumb deposit empower calm across dawn slice simple crisp soon oak" | $BINARY keys add $KEY2 --keyring-backend $KEYRING --recover --home $HOME
 
 # Allocate genesis accounts (cosmos formatted addresses)
 $BINARY add-genesis-account $KEY "1000000000000${DENOM}" --keyring-backend $KEYRING --home $HOME
 
 $BINARY add-genesis-account $KEY1 "1000000000000${DENOM}" --keyring-backend $KEYRING --home $HOME
+$BINARY add-genesis-account $KEY2 "1000000000000${DENOM}" --keyring-backend $KEYRING --home $HOME
 
 update_test_genesis '.app_state["gov"]["voting_params"]["voting_period"] = "50s"'
 update_test_genesis '.app_state["mint"]["params"]["mint_denom"]=$DENOM' $DENOM
 update_test_genesis '.app_state["gov"]["deposit_params"]["min_deposit"]=[{"denom": $DENOM,"amount": "1000000"}]' $DENOM
 update_test_genesis '.app_state["crisis"]["constant_fee"]={"denom": $DENOM,"amount": "1000"}' $DENOM
 update_test_genesis '.app_state["staking"]["params"]["bond_denom"]=$DENOM' $DENOM
+update_test_genesis '.app_state["storage"]["misses_to_burn"]=2' $DENOM
+update_test_genesis '.app_state["storage"]["proof_window"]=3' $DENOM
 
 
 sed -i '' 's/enable = false/enable = true/' $HOME/config/app.toml

--- a/scripts/run-upgrade-node.sh
+++ b/scripts/run-upgrade-node.sh
@@ -36,7 +36,7 @@ update_test_genesis '.app_state["gov"]["deposit_params"]["min_deposit"]=[{"denom
 update_test_genesis '.app_state["crisis"]["constant_fee"]={"denom": $DENOM,"amount": "1000"}' $DENOM
 update_test_genesis '.app_state["staking"]["params"]["bond_denom"]=$DENOM' $DENOM
 update_test_genesis '.app_state["storage"]["params"]["misses_to_burn"]=2' $DENOM
-update_test_genesis '.app_state["storage"]["params"]["proof_window"]=3' $DENOM
+update_test_genesis '.app_state["storage"]["params"]["proof_window"]=10' $DENOM
 update_test_genesis '.app_state["storage"]["params"]["deposit_account"]="jkl12g4qwenvpzqeakavx5adqkw203s629tf6k8vdg"' $DENOM
 
 

--- a/scripts/run-upgrade-node.sh
+++ b/scripts/run-upgrade-node.sh
@@ -36,7 +36,7 @@ update_test_genesis '.app_state["gov"]["deposit_params"]["min_deposit"]=[{"denom
 update_test_genesis '.app_state["crisis"]["constant_fee"]={"denom": $DENOM,"amount": "1000"}' $DENOM
 update_test_genesis '.app_state["staking"]["params"]["bond_denom"]=$DENOM' $DENOM
 update_test_genesis '.app_state["storage"]["params"]["misses_to_burn"]=2' $DENOM
-update_test_genesis '.app_state["storage"]["params"]["proof_window"]=6' $DENOM
+update_test_genesis '.app_state["storage"]["params"]["proof_window"]=4' $DENOM
 update_test_genesis '.app_state["storage"]["params"]["deposit_account"]="jkl12g4qwenvpzqeakavx5adqkw203s629tf6k8vdg"' $DENOM
 
 

--- a/scripts/run-upgrade-node.sh
+++ b/scripts/run-upgrade-node.sh
@@ -35,8 +35,8 @@ update_test_genesis '.app_state["mint"]["params"]["mint_denom"]=$DENOM' $DENOM
 update_test_genesis '.app_state["gov"]["deposit_params"]["min_deposit"]=[{"denom": $DENOM,"amount": "1000000"}]' $DENOM
 update_test_genesis '.app_state["crisis"]["constant_fee"]={"denom": $DENOM,"amount": "1000"}' $DENOM
 update_test_genesis '.app_state["staking"]["params"]["bond_denom"]=$DENOM' $DENOM
-update_test_genesis '.app_state["storage"]["misses_to_burn"]=2' $DENOM
-update_test_genesis '.app_state["storage"]["proof_window"]=3' $DENOM
+update_test_genesis '.app_state["storage"]["params"]["misses_to_burn"]=2' $DENOM
+update_test_genesis '.app_state["storage"]["params"]["proof_window"]=3' $DENOM
 
 
 sed -i '' 's/enable = false/enable = true/' $HOME/config/app.toml

--- a/scripts/run-upgrade-node.sh
+++ b/scripts/run-upgrade-node.sh
@@ -37,7 +37,7 @@ update_test_genesis '.app_state["crisis"]["constant_fee"]={"denom": $DENOM,"amou
 update_test_genesis '.app_state["staking"]["params"]["bond_denom"]=$DENOM' $DENOM
 update_test_genesis '.app_state["storage"]["params"]["misses_to_burn"]=2' $DENOM
 update_test_genesis '.app_state["storage"]["params"]["proof_window"]=3' $DENOM
-update_test_genesis '.app_state["storage"]["params"]["deposit_account:"]=jkl12g4qwenvpzqeakavx5adqkw203s629tf6k8vdg' $DENOM
+update_test_genesis '.app_state["storage"]["params"]["deposit_account"]=jkl12g4qwenvpzqeakavx5adqkw203s629tf6k8vdg' $DENOM
 
 
 sed -i '' 's/enable = false/enable = true/' $HOME/config/app.toml

--- a/scripts/run-upgrade-node.sh
+++ b/scripts/run-upgrade-node.sh
@@ -36,7 +36,7 @@ update_test_genesis '.app_state["gov"]["deposit_params"]["min_deposit"]=[{"denom
 update_test_genesis '.app_state["crisis"]["constant_fee"]={"denom": $DENOM,"amount": "1000"}' $DENOM
 update_test_genesis '.app_state["staking"]["params"]["bond_denom"]=$DENOM' $DENOM
 update_test_genesis '.app_state["storage"]["params"]["misses_to_burn"]=2' $DENOM
-update_test_genesis '.app_state["storage"]["params"]["proof_window"]=10' $DENOM
+update_test_genesis '.app_state["storage"]["params"]["proof_window"]=6' $DENOM
 update_test_genesis '.app_state["storage"]["params"]["deposit_account"]="jkl12g4qwenvpzqeakavx5adqkw203s629tf6k8vdg"' $DENOM
 
 

--- a/scripts/upgrade-test.sh
+++ b/scripts/upgrade-test.sh
@@ -2,7 +2,7 @@
 
 OLD_VERSION=$1
 NEW_VERSION=$2
-UPGRADE_HEIGHT=26
+UPGRADE_HEIGHT=30
 HOME=mytestnet
 ROOT=$(pwd)
 DENOM=ujkl
@@ -69,11 +69,11 @@ sleep 6
 
 sleep 6
 
-./../_build/old/canined tx storage post-contract jklc1003g00zclz5hv3kku8vtjptzx042hpm6zjpyf7me8vvu2ucv2aas4pq3nv jkl12g4qwenvpzqeakavx5adqkw203s629tf6k8vdg 10000 jklf1rqry0q7a55tanxkv34rnza82pewfm292pr77m78vc8avjk5p3e9sc6qgnq --from test1 --keyring-backend test --chain-id test --home $HOME -y
+./../_build/old/canined tx storage post-contract jklc1hufzy29uulvfcpw9xsat0fs87vglyslj8sc0cz270necl9u23hzsczp0s3 jkl12g4qwenvpzqeakavx5adqkw203s629tf6k8vdg 10000 jklf1rqry0q7a55tanxkv34rnza82pewfm292pr77m78vc8avjk5p3e9sc6qgnq --from test1 --keyring-backend test --chain-id test --home $HOME -y
 
 sleep 6
 
-./../_build/old/canined tx storage sign-contract jklc1003g00zclz5hv3kku8vtjptzx042hpm6zjpyf7me8vvu2ucv2aas4pq3nv --from test1 --keyring-backend test --chain-id test --home $HOME -y
+./../_build/old/canined tx storage sign-contract jklc1hufzy29uulvfcpw9xsat0fs87vglyslj8sc0cz270necl9u23hzsczp0s3 --from test1 --keyring-backend test --chain-id test --home $HOME -y
 
 
 # determine block_height to halt

--- a/scripts/upgrade-test.sh
+++ b/scripts/upgrade-test.sh
@@ -43,7 +43,7 @@ sleep 6
 
 sleep 6
 
-./../_build/old/canined tx storage post-contract jklc10zpctnu6qu4dkvzx2u9jpvk6hr8z3qnfpzlmf63ejqdgjgr5h5qszdqylf jkl12g4qwenvpzqeakavx5adqkw203s629tf6k8vdg 10000 jkl12g4qwenvpzqeakavx5adqkw203s629tf6k8vdg --from test1 --keyring-backend test --chain-id test --home $HOME -y
+./../_build/old/canined tx storage post-contract jklc10zpctnu6qu4dkvzx2u9jpvk6hr8z3qnfpzlmf63ejqdgjgr5h5qszdqylf jkl12g4qwenvpzqeakavx5adqkw203s629tf6k8vdg 10000 jklf16yfjl9t8u9ztt0e5wzudpfr3e2u5cxwsru6l6jh930zrvav5cz2q2wrfkc --from test1 --keyring-backend test --chain-id test --home $HOME -y
 
 sleep 6
 

--- a/scripts/upgrade-test.sh
+++ b/scripts/upgrade-test.sh
@@ -25,6 +25,7 @@ make install
 screen -dmS node1 bash scripts/run-upgrade-node.sh ./../_build/old/canined $DENOM
 
 ./../_build/old/canined version --home $HOME
+./../_build/old/canined q storage params --home $HOME
 
 sleep 20
 
@@ -33,6 +34,7 @@ sleep 20
 sleep 6
 
 ./../_build/old/canined provider init http://localhost:3333 10000000 ""  --from test1 --keyring-backend test --chain-id test --home $HOME -y
+./../_build/old/canined provider init http://localhost:3333 10000000 ""  --from test2 --keyring-backend test --chain-id test --home $HOME -y
 
 sleep 6
 

--- a/scripts/upgrade-test.sh
+++ b/scripts/upgrade-test.sh
@@ -25,11 +25,12 @@ make install
 screen -dmS node1 bash scripts/run-upgrade-node.sh ./../_build/old/canined $DENOM
 
 ./../_build/old/canined version --home $HOME
+
+sleep 30
+
 ./../_build/old/canined q storage params --home $HOME
 
-sleep 20
-
-./../_build/old/canined tx storage buy-storage $(./../_build/old/canined keys show test1 -a --keyring-backend test --chain-id test --home $HOME) 720h 1000000000 ujkl --from test1 --keyring-backend test --chain-id test --home $HOME -y
+./../_build/old/canined tx storage buy-storage $(./../_build/old/canined keys show test1 -a --keyring-backend test --home $HOME) 720h 1000000000 ujkl --from test1 --keyring-backend test --chain-id test --home $HOME -y
 
 sleep 6
 

--- a/scripts/upgrade-test.sh
+++ b/scripts/upgrade-test.sh
@@ -30,7 +30,7 @@ sleep 30
 
 ./../_build/old/canined q storage params --home $HOME
 
-./../_build/old/canined tx storage buy-storage $(./../_build/old/canined keys show test1 -a --keyring-backend test --home $HOME) 720h 1000000000 ujkl --from test1 --keyring-backend test --chain-id test --home $HOME -y
+./../_build/old/canined tx storage buy-storage "$(./../_build/old/canined keys show test1 -a --keyring-backend test --home $HOME)" 720h 1000000000 ujkl --from test1 --keyring-backend test --chain-id test --home $HOME -y
 
 sleep 6
 
@@ -43,7 +43,7 @@ sleep 6
 
 sleep 6
 
-./../_build/old/canined tx storage post-contract jklc10zpctnu6qu4dkvzx2u9jpvk6hr8z3qnfpzlmf63ejqdgjgr5h5qszdqylf $(./../_build/old/canined keys show test1 -a --keyring-backend test --chain-id test --home $HOME) 10000 jklf16yfjl9t8u9ztt0e5wzudpfr3e2u5cxwsru6l6jh930zrvav5cz2q2wrfkc --from test1 --keyring-backend test --chain-id test --home $HOME -y
+./../_build/old/canined tx storage post-contract jklc10zpctnu6qu4dkvzx2u9jpvk6hr8z3qnfpzlmf63ejqdgjgr5h5qszdqylf jkl12g4qwenvpzqeakavx5adqkw203s629tf6k8vdg 10000 jkl12g4qwenvpzqeakavx5adqkw203s629tf6k8vdg --from test1 --keyring-backend test --chain-id test --home $HOME -y
 
 sleep 6
 

--- a/scripts/upgrade-test.sh
+++ b/scripts/upgrade-test.sh
@@ -25,6 +25,7 @@ make install
 screen -dmS node1 bash scripts/run-upgrade-node.sh ./../_build/old/canined $DENOM
 
 ./../_build/old/canined version --home $HOME
+./../_build/old/canined config broadcast-mode block --home $HOME
 
 sleep 30
 
@@ -67,6 +68,13 @@ sleep 6
 ./../_build/old/canined tx gov vote 1 yes --from test1 --keyring-backend test --chain-id test --home $HOME -y
 
 sleep 6
+
+./../_build/old/canined tx storage post-contract jklc1003g00zclz5hv3kku8vtjptzx042hpm6zjpyf7me8vvu2ucv2aas4pq3nv jkl12g4qwenvpzqeakavx5adqkw203s629tf6k8vdg 10000 jklf1rqry0q7a55tanxkv34rnza82pewfm292pr77m78vc8avjk5p3e9sc6qgnq --from test1 --keyring-backend test --chain-id test --home $HOME -y
+
+sleep 6
+
+./../_build/old/canined tx storage sign-contract jklc1003g00zclz5hv3kku8vtjptzx042hpm6zjpyf7me8vvu2ucv2aas4pq3nv --from test1 --keyring-backend test --chain-id test --home $HOME -y
+
 
 # determine block_height to halt
 while true; do 

--- a/scripts/upgrade-test.sh
+++ b/scripts/upgrade-test.sh
@@ -30,7 +30,7 @@ sleep 30
 
 ./../_build/old/canined q storage params --home $HOME
 
-./../_build/old/canined tx storage buy-storage "$(./../_build/old/canined keys show test1 -a --keyring-backend test --home $HOME)" 720h 1000000000 ujkl --from test1 --keyring-backend test --chain-id test --home $HOME -y
+./../_build/old/canined tx storage buy-storage jkl12g4qwenvpzqeakavx5adqkw203s629tf6k8vdg 720h 1000000000 ujkl --from test1 --keyring-backend test --chain-id test --home $HOME -y
 
 sleep 6
 

--- a/x/storage/abci.go
+++ b/x/storage/abci.go
@@ -18,4 +18,10 @@ func BeginBlocker(ctx sdk.Context, k keeper.Keeper) {
 	}
 
 	k.KillOldContracts(ctx)
+
+	var week int64 = (7 * 24 * 60 * 60) / 6
+
+	if ctx.BlockHeight()%week == 0 { // clear out files once a week
+		k.ClearDeadFiles(ctx)
+	}
 }


### PR DESCRIPTION
Following the initial instability of the Jackal network, there were a couple of providers that shut down and caused some early files to be lost, this has since caused the lost files. There is always the chance that a file is lost forever, this chance is tiny and can only happen when all 3 providers that are storing a file shut down within a short window of time. This is being improved through error-correcting codes in the future. Until then this is the best chance at optimizing an already full "dead files pile". This removes all strays that don't share an FID with an active deal. This will happen once upon upgrading and then once every week following. These weekly purges may cause the block times to be slightly longer for an individual block.