### PR TITLE
Fix: Fid-Cid map properly updates after canceling contract

### DIFF
--- a/x/storage/keeper/msg_server_contracts_test.go
+++ b/x/storage/keeper/msg_server_contracts_test.go
@@ -375,7 +375,7 @@ func (suite *KeeperTestSuite) TestCancelContract() {
 				}
 			},
 			expErr:    true,
-			expErrMsg: "no deal found: key not found",
+			expErrMsg: "cid does not exist",
 		},
 
 		{
@@ -517,11 +517,20 @@ func (suite *KeeperTestSuite) TestCancelContract() {
 			suite.Require().NotNil(tc.preRun)
 			c := tc.preRun()
 			_, err := msgSrvr.CancelContract(goCtx, c)
+
 			if tc.expErr {
 				suite.Require().Error(err)
 				suite.Require().Contains(err.Error(), tc.expErrMsg)
 			} else {
 				suite.Require().NoError(err)
+				fidCid, found := suite.storageKeeper.GetFidCid(suite.ctx, "jklf1j3p63s42w7ywaczlju626st55mzu5z39w2rx9x")
+				suite.Require().True(found)
+				var cids []string
+				err := json.Unmarshal([]byte(fidCid.Cids), &cids) // getting all cids from the existing fid_cid
+				if err != nil {
+					suite.Require().NoError(err)
+				}
+				suite.Require().Equal(0, len(cids))
 			}
 
 			if tc.postRun != nil {

--- a/x/storage/keeper/rewards.go
+++ b/x/storage/keeper/rewards.go
@@ -171,7 +171,7 @@ func (k Keeper) loopDeals(ctx sdk.Context, allDeals []types.ActiveDeals, network
 		info, found := k.GetStoragePaymentInfo(ctx, deal.Signee)
 		if !found {
 			ctx.Logger().Debug(fmt.Sprintf("Removing %s due to no payment info", deal.Cid))
-			cerr := CanContract(ctx, deal.Cid, deal.Signee, k)
+			cerr := k.CanContract(ctx, deal.Cid, deal.Signee)
 			if cerr != nil {
 				ctx.Logger().Error(cerr.Error())
 			}
@@ -180,7 +180,7 @@ func (k Keeper) loopDeals(ctx sdk.Context, allDeals []types.ActiveDeals, network
 		grace := info.End.Add(time.Hour * 24 * 30)
 		if grace.Before(ctx.BlockTime()) {
 			ctx.Logger().Debug(fmt.Sprintf("Removing %s after grace period", deal.Cid))
-			cerr := CanContract(ctx, deal.Cid, deal.Signee, k)
+			cerr := k.CanContract(ctx, deal.Cid, deal.Signee)
 			if cerr != nil {
 				ctx.Logger().Error(cerr.Error())
 			}
@@ -189,7 +189,7 @@ func (k Keeper) loopDeals(ctx sdk.Context, allDeals []types.ActiveDeals, network
 
 		if info.SpaceUsed > info.SpaceAvailable { // remove file if the user doesn't have enough space
 			ctx.Logger().Debug(fmt.Sprintf("Removing %s for space used", deal.Cid))
-			err := CanContract(ctx, deal.Cid, deal.Signee, k)
+			err := k.CanContract(ctx, deal.Cid, deal.Signee)
 			if err != nil {
 				ctx.Logger().Error(err.Error())
 			}

--- a/x/storage/types/errors.go
+++ b/x/storage/types/errors.go
@@ -12,4 +12,5 @@ var (
 	ErrProviderNotFound   = sdkerrors.Register(ModuleName, 1111, "Provider not found. Please init your provider.")
 	ErrNotValidTotalSpace = sdkerrors.Register(ModuleName, 1112, "Not a valid total space. Please enter total number of bytes to provide.")
 	ErrCannotVerifyProof  = sdkerrors.Register(ModuleName, 1113, "Cannot verify Proof")
+	ErrNoCid              = sdkerrors.Register(ModuleName, 1114, "cid does not exist")
 )


### PR DESCRIPTION
Sometimes when cancelling a contract using the cancel contract method, the fid-cid map would be thrown off and keep a dead cid around, this no longer happens and the test suite accurately reflects this.