### PR TITLE
Perps Rounding to Mbs instead of Gbs

### DIFF
--- a/x/storage/keeper/msg_server_sign_contract.go
+++ b/x/storage/keeper/msg_server_sign_contract.go
@@ -49,11 +49,11 @@ func (k msgServer) SignContract(goCtx context.Context, msg *types.MsgSignContrac
 
 	var end int64
 	if msg.PayOnce {
-		s := size.Quo(sdk.NewInt(1_000_000_000)).Int64()
+		s := size.Quo(sdk.NewInt(1_000_000)).Int64() // round to mbs
 		if s <= 0 {
 			s = 1
 		}
-		cost := k.GetStorageCost(ctx, s, 720*12*200) // pay for 200 years
+		cost := k.GetStorageCostKbs(ctx, s*1000, 720*12*200) // pay for 200 years in mbs
 		deposit, err := sdk.AccAddressFromBech32(k.GetParams(ctx).DepositAccount)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Perpetual storage pricing is now adjusted to use a minimum of 1mb instead of 1gb.