### PR TITLE
Patch 3.2.0 ibc go to 4.6.0 - non-consensus breaking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/cockroachdb/redact v1.1.3 // indirect
 	github.com/coinbase/rosetta-sdk-go v0.7.9 // indirect
 	github.com/cometbft/cometbft-db v0.7.0 // indirect
-	github.com/confio/ics23/go v0.9.0 // indirect
+	github.com/confio/ics23/go v0.9.1 // indirect
 	github.com/cosmos/btcutil v1.0.4 // indirect
 	github.com/cosmos/cosmos-db v0.0.0-20221226095112-f3c38ecb5e32 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
@@ -183,3 +183,5 @@ replace (
 	// use grpc compatible with cosmos-flavored protobufs
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )
+
+replace github.com/cosmos/ibc-go/v4 => github.com/cosmos/ibc-go/v4 v4.6.0

--- a/go.sum
+++ b/go.sum
@@ -273,8 +273,8 @@ github.com/cosmos/gorocksdb v1.2.0 h1:d0l3jJG8M4hBouIZq0mDUHZ+zjOx044J3nGRskwTb4
 github.com/cosmos/gorocksdb v1.2.0/go.mod h1:aaKvKItm514hKfNJpUJXnnOWeBnk2GL4+Qw9NHizILw=
 github.com/cosmos/iavl v0.19.5 h1:rGA3hOrgNxgRM5wYcSCxgQBap7fW82WZgY78V9po/iY=
 github.com/cosmos/iavl v0.19.5/go.mod h1:X9PKD3J0iFxdmgNLa7b2LYWdsGd90ToV5cAONApkEPw=
-github.com/cosmos/ibc-go/v4 v4.4.2 h1:PG4Yy0/bw6Hvmha3RZbc53KYzaCwuB07Ot4GLyzcBvo=
-github.com/cosmos/ibc-go/v4 v4.4.2/go.mod h1:j/kD2JCIaV5ozvJvaEkWhLxM2zva7/KTM++EtKFYcB8=
+github.com/cosmos/ibc-go/v4 v4.6.0 h1:G7kiD4Zf8Wrxc8BXWIKuFnzI0W4wpvRPrl5HwdfTIsA=
+github.com/cosmos/ibc-go/v4 v4.6.0/go.mod h1:ksiZHUypws0NVP50E3ea0ivVFO/bfS8q8yLg8yZ2ATQ=
 github.com/cosmos/interchain-accounts v0.2.6 h1:TV2M2g1/Rb9MCNw1YePdBKE0rcEczNj1RGHT+2iRYas=
 github.com/cosmos/interchain-accounts v0.2.6/go.mod h1:lUzWNzCiCtIEYZefac5+YgEBz2aR39nMS374jIv1c7o=
 github.com/cosmos/keyring v1.2.0 h1:8C1lBP9xhImmIabyXW4c3vFjjLiBdGCmfLUfeZlV1Yo=


### PR DESCRIPTION
The current vulnerability in IBC GO:  https://github.com/cosmos/ibc-go/security/advisories/GHSA-j496-crgh-34mx

Updating to v4.6.0 - non-consensus breaking.

Stargaze pushed this updated as a private patch before release.  It was mentioned then it was non-consensus breaking and we could upgrade as soon as we saw the announcement.

I patched my version of the binary and have been running it on the IBC GO v4.6.0 today just fine.  I am missing less blocks currently.  I have made some changes recently to my timeout_propose that has drastically helped me to miss less blocks.  Lowering that time has been beneficial.
But when receiving incoming IBC packets, my node would appear to 'hang'.  It appeared that something was causing a 'timeout' or some delay after receiving an IBC packet and then going back to the consensus module.  I don't know if there was difficulty in some way injecting the tx into the mempool or not.  However, I am now seeing this happen far less.

```
jackal@artorias:~$ canined version --long
name: canine
server_name: canined
version: 3.2.0
commit: d737e32750a56c875706ab3788eb700929a8965f
build_tags: netgo,ledger,pebbledb
go: go version go1.22.1 linux/amd64
build_deps:
- cosmossdk.io/api@v0.2.6
- cosmossdk.io/core@v0.5.1
- cosmossdk.io/depinject@v1.0.0-alpha.3
- filippo.io/edwards25519@v1.0.0-rc.1
- github.com/99designs/keyring@v1.2.1 => github.com/cosmos/keyring@v1.2.0
- github.com/ChainSafe/go-schnorrkel@v0.0.0-20200405005733-88cbf1b4c40d
- github.com/CosmWasm/wasmd@v0.32.0
- github.com/CosmWasm/wasmvm@v1.2.6
- github.com/DataDog/zstd@v1.5.2
- github.com/Workiva/go-datastructures@v1.0.53
- github.com/armon/go-metrics@v0.4.1
- github.com/beorn7/perks@v1.0.1
- github.com/bgentry/speakeasy@v0.1.1-0.20220910012023-760eaf8b6816
- github.com/btcsuite/btcd/btcec/v2@v2.3.2
- github.com/cespare/xxhash/v2@v2.2.0
- github.com/cockroachdb/errors@v1.9.1
- github.com/cockroachdb/logtags@v0.0.0-20230118201751-21c54148d20b
- github.com/cockroachdb/pebble@v1.0.0
- github.com/cockroachdb/redact@v1.1.3
- github.com/coinbase/rosetta-sdk-go@v0.7.9
- github.com/cometbft/cometbft-db@v0.7.0 => github.com/notional-labs/cometbft-db@v0.0.0-20240124141910-d74f5dec49a7
- github.com/confio/ics23/go@v0.9.1 => github.com/cosmos/cosmos-sdk/ics23/go@v0.8.0
- github.com/cosmos/btcutil@v1.0.4
- github.com/cosmos/cosmos-db@v0.0.0-20221226095112-f3c38ecb5e32
- github.com/cosmos/cosmos-proto@v1.0.0-beta.3
- github.com/cosmos/cosmos-sdk@v0.45.17 => github.com/JackalLabs/cosmos-sdk-new@v0.45.17-0.20230704034202-b88b1fbc9b2f
- github.com/cosmos/go-bip39@v1.0.0
- github.com/cosmos/gogoproto@v1.4.10
- github.com/cosmos/iavl@v0.19.5
- github.com/cosmos/ibc-go/v4@v4.4.2 => github.com/cosmos/ibc-go/v4@v4.6.0
- github.com/cosmos/interchain-accounts@v0.2.6
- github.com/cosmos/ledger-cosmos-go@v0.12.4
- github.com/creachadair/taskgroup@v0.3.2
- github.com/davecgh/go-spew@v1.1.1
- github.com/decred/dcrd/dcrec/secp256k1/v4@v4.2.0
- github.com/desertbit/timer@v0.0.0-20180107155436-c41aec40b27f
- github.com/docker/distribution@v2.8.1+incompatible
- github.com/dvsekhvalnov/jose2go@v1.5.0
- github.com/ecies/go/v2@v2.0.6
- github.com/ethereum/go-ethereum@v1.11.5
- github.com/felixge/httpsnoop@v1.0.2
- github.com/fsnotify/fsnotify@v1.6.0
- github.com/getsentry/sentry-go@v0.18.0
- github.com/go-kit/kit@v0.12.0
- github.com/go-kit/log@v0.2.1
- github.com/go-logfmt/logfmt@v0.5.1
- github.com/godbus/dbus@v0.0.0-20190726142602-4481cbc300e2
- github.com/gogo/gateway@v1.1.0
- github.com/gogo/protobuf@v1.3.3 => github.com/regen-network/protobuf@v1.3.3-alpha.regen.1
- github.com/golang/protobuf@v1.5.3
- github.com/golang/snappy@v0.0.4
- github.com/google/btree@v1.1.2
- github.com/google/go-cmp@v0.6.0
- github.com/google/gofuzz@v1.2.0
- github.com/google/orderedcode@v0.0.1
- github.com/google/uuid@v1.3.0
- github.com/gorilla/handlers@v1.5.1
- github.com/gorilla/mux@v1.8.0
- github.com/gorilla/websocket@v1.5.0
- github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0
- github.com/grpc-ecosystem/grpc-gateway@v1.16.0
- github.com/gsterjov/go-libsecret@v0.0.0-20161001094733-a6f4afe4910c
- github.com/gtank/merlin@v0.1.1
- github.com/gtank/ristretto255@v0.1.2
- github.com/hashicorp/go-immutable-radix@v1.3.1
- github.com/hashicorp/golang-lru@v0.5.5-0.20210104140557-80c98217689d
- github.com/hashicorp/hcl@v1.0.0
- github.com/hdevalence/ed25519consensus@v0.0.0-20220222234857-c00d1f31bab3
- github.com/improbable-eng/grpc-web@v0.14.1
- github.com/klauspost/compress@v1.16.3
- github.com/kr/pretty@v0.3.1
- github.com/kr/text@v0.2.0
- github.com/lib/pq@v1.10.7
- github.com/libp2p/go-buffer-pool@v0.1.0
- github.com/magiconair/properties@v1.8.6
- github.com/mattn/go-colorable@v0.1.13
- github.com/mattn/go-isatty@v0.0.16
- github.com/matttproud/golang_protobuf_extensions@v1.0.4
- github.com/mimoo/StrobeGo@v0.0.0-20210601165009-122bf33a46e0
- github.com/minio/highwayhash@v1.0.2
- github.com/mitchellh/mapstructure@v1.5.0
- github.com/mtibben/percent@v0.2.1
- github.com/opencontainers/go-digest@v1.0.0
- github.com/pelletier/go-toml/v2@v2.0.5
- github.com/pkg/errors@v0.9.1
- github.com/pmezard/go-difflib@v1.0.0
- github.com/prometheus/client_golang@v1.16.0
- github.com/prometheus/client_model@v0.3.0
- github.com/prometheus/common@v0.42.0
- github.com/prometheus/procfs@v0.10.1
- github.com/rakyll/statik@v0.1.7
- github.com/rcrowley/go-metrics@v0.0.0-20201227073835-cf1acfcdf475
- github.com/regen-network/cosmos-proto@v0.3.1
- github.com/rogpeppe/go-internal@v1.9.0
- github.com/rs/cors@v1.8.2
- github.com/rs/zerolog@v1.27.0
- github.com/spf13/afero@v1.9.2
- github.com/spf13/cast@v1.5.1
- github.com/spf13/cobra@v1.7.0
- github.com/spf13/jwalterweatherman@v1.1.0
- github.com/spf13/pflag@v1.0.5
- github.com/spf13/viper@v1.14.0
- github.com/stretchr/testify@v1.8.4
- github.com/subosito/gotenv@v1.4.1
- github.com/syndtr/goleveldb@v1.0.1-0.20210819022825-2ae1ddf74ef7
- github.com/tendermint/go-amino@v0.16.0
- github.com/tendermint/tendermint@v0.34.27 => github.com/cometbft/cometbft@v0.34.27
- github.com/tendermint/tm-db@v0.6.7 => github.com/notional-labs/tm-db@v0.6.8-0.20240206021653-7664d28b4854
- github.com/tidwall/btree@v1.5.0
- github.com/wealdtech/go-merkletree@v1.0.0 => github.com/TheMarstonConnell/go-merkletree@v0.0.0-20230124030923-93fb10e701d7
- github.com/zondax/hid@v0.9.2
- github.com/zondax/ledger-go@v0.14.3
- golang.org/x/crypto@v0.15.0
- golang.org/x/exp@v0.0.0-20230321023759-10a507213a29
- golang.org/x/net@v0.18.0
- golang.org/x/sys@v0.14.0
- golang.org/x/term@v0.14.0
- golang.org/x/text@v0.14.0
- google.golang.org/genproto@v0.0.0-20230320184635-7606e756e683
- google.golang.org/grpc@v1.55.0 => google.golang.org/grpc@v1.33.2
- google.golang.org/protobuf@v1.31.0
- gopkg.in/ini.v1@v1.67.0
- gopkg.in/yaml.v2@v2.4.0
- gopkg.in/yaml.v3@v3.0.1
- nhooyr.io/websocket@v1.8.6
cosmos_sdk_version: v0.45.17
```