### PR TITLE
Claim strays using less memory

### DIFF
--- a/x/storage/keeper/rewards.go
+++ b/x/storage/keeper/rewards.go
@@ -221,7 +221,6 @@ func (k Keeper) InternalRewards(ctx sdk.Context, allDeals []types.ActiveDeals, a
 }
 
 func (k Keeper) HandleRewardBlock(ctx sdk.Context) error {
-
 	DayBlocks := k.GetParams(ctx).ProofWindow
 
 	if ctx.BlockHeight()%DayBlocks > 0 {


### PR DESCRIPTION
# Claim Strays Memory Fix
### Never again
<img width="260" alt="image" src="https://github.com/JackalLabs/canine-chain/assets/34043723/e00b2fa4-92ee-4407-8cba-d9e51284143b">

Essentially, we were loading ever active deal every time a stray was claimed, now we try to use `fid_cid` mappings to make the lookup faster, and if that for some reason fails, we fall back on loading every active deal. This should improve memory usage A LOT!
