### PR TITLE
make GetAllActiveProviders more efficient

### DIFF
--- a/x/storage/keeper/proofs.go
+++ b/x/storage/keeper/proofs.go
@@ -125,13 +125,13 @@ func (k Keeper) GetOneProofForProver(ctx sdk.Context, prover string) (types.File
 
 	defer iterator.Close()
 
-	for ; iterator.Valid(); iterator.Next() {
-		var proof types.FileProof
+	var proof types.FileProof
+	if iterator.Valid() {
 		if err := k.cdc.Unmarshal(iterator.Value(), &proof); err != nil {
 			return proof, err
 		}
 		return proof, nil
 	}
 
-	return types.FileProof{}, fmt.Errorf("no proofs found for prover")
+	return proof, fmt.Errorf("no proofs found for prover")
 }

--- a/x/storage/keeper/proofs.go
+++ b/x/storage/keeper/proofs.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/jackalLabs/canine-chain/v4/x/storage/types"

--- a/x/storage/keeper/proofs.go
+++ b/x/storage/keeper/proofs.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"fmt"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/jackalLabs/canine-chain/v4/x/storage/types"
@@ -114,4 +115,23 @@ func (k Keeper) GetAllProofsForProver(ctx sdk.Context, prover string) ([]types.F
 	}
 
 	return proofs, nil
+}
+
+// GetOneProofForProver returns one Proof for the given prover
+func (k Keeper) GetOneProofForProver(ctx sdk.Context, prover string) (types.FileProof, error) {
+	store := ctx.KVStore(k.storeKey)
+	proofStore := prefix.NewStore(store, types.ProofPrefix(prover))
+	iterator := sdk.KVStorePrefixIterator(proofStore, nil)
+
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		var proof types.FileProof
+		if err := k.cdc.Unmarshal(iterator.Value(), &proof); err != nil {
+			return proof, err
+		}
+		return proof, nil
+	}
+
+	return types.FileProof{}, fmt.Errorf("no proofs found for prover")
 }

--- a/x/storage/keeper/providers.go
+++ b/x/storage/keeper/providers.go
@@ -200,8 +200,8 @@ func (k Keeper) GetAllActiveProviders(ctx sdk.Context) (list []types.ActiveProvi
 		var val types.Providers
 		k.cdc.MustUnmarshal(iterator.Value(), &val)
 
-		l, _ := k.GetAllProofsForProver(ctx, val.Address)
-		if len(l) >= 1 {
+		_, err := k.GetOneProofForProver(ctx, val.Address)
+		if err == nil {
 			list = append(list, types.ActiveProviders{Address: val.Address})
 		}
 	}


### PR DESCRIPTION
### Description
As of late, some webapps I've been working on are struggling to initialize when querying a list of all active providers. This often leads to a gateway timeout, internal server error, among other issues.

This was due to the sheer number of proofs that exist now as we approach 100k files stored. Here's a small patch to avoid the problem alltogether.

### Testing
I used Haruka Nodes on mainnet to test these changes. Initially, via an gRPC query it took up to 3 minutes to respond to the request for ActiveProviders. Attempts with RPC endpoints (Jackal internalrpc, Brochain, Mathnodes, Stavr) have led to similar results, often timing out around 40s.

After the changes were implemented, my gRPC query responded in 523ms and delivered the same result.

Cheers 🍻


