### PR TITLE
Building Filebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.swn
 .vscode
 .idea
+.db
 
 vue
 ts-client

--- a/app/app.go
+++ b/app/app.go
@@ -1,7 +1,9 @@
 package app
 
 import (
+	"database/sql"
 	"fmt"
+	_ "github.com/mattn/go-sqlite3"
 	"io"
 	"net/http"
 	"os"
@@ -617,6 +619,9 @@ func NewJackalApp(
 	)
 	oracleModule := oraclemodule.NewAppModule(appCodec, app.OracleKeeper, app.AccountKeeper, app.BankKeeper)
 
+	filebaseDir := filepath.Join(homePath, "filebase.db")
+	fibase, err := sql.Open("sqlite3", filebaseDir)
+
 	app.StorageKeeper = *storagemodulekeeper.NewKeeper(
 		appCodec,
 		keys[storagemoduletypes.StoreKey],
@@ -626,6 +631,7 @@ func NewJackalApp(
 		app.OracleKeeper,
 		app.RnsKeeper,
 		authtypes.FeeCollectorName,
+		fibase,
 	)
 	storageModule := storagemodule.NewAppModule(appCodec, app.StorageKeeper, app.AccountKeeper, app.BankKeeper, app.getSubspace(storagemoduletypes.ModuleName))
 

--- a/app/upgrades/v4/commont_test.go
+++ b/app/upgrades/v4/commont_test.go
@@ -1,9 +1,8 @@
 package v4_test
 
 import (
+	"database/sql"
 	"fmt"
-	"testing"
-
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/golang/mock/gomock"
@@ -12,6 +11,10 @@ import (
 	storagekeeper "github.com/jackalLabs/canine-chain/v4/x/storage/keeper"
 	storagetestutil "github.com/jackalLabs/canine-chain/v4/x/storage/testutil"
 	storagemoduletypes "github.com/jackalLabs/canine-chain/v4/x/storage/types"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+	"path"
+	"testing"
 
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	typesparams "github.com/cosmos/cosmos-sdk/x/params/types"
@@ -111,8 +114,13 @@ func SetupStorageKeeper(t *testing.T) (
 		"StorageParams",
 	)
 
+	n := path.Join(t.TempDir(), "filebase.db")
+	t.Log("temp filebase name: ", n)
+	d, err := sql.Open("sqlite3", n)
+	require.New(t).NoError(err)
+
 	// storage keeper initializations
-	storageKeeper := storagekeeper.NewKeeper(encCfg.Codec, key, paramsSubspace, bankKeeper, accountKeeper, oracleKeeper, rnsKeeper, authtypes.FeeCollectorName)
+	storageKeeper := storagekeeper.NewKeeper(encCfg.Codec, key, paramsSubspace, bankKeeper, accountKeeper, oracleKeeper, rnsKeeper, authtypes.FeeCollectorName, d)
 	storageKeeper.SetParams(ctx, storagemoduletypes.DefaultParams())
 
 	// Register all handlers for the MegServiceRouter.
@@ -179,8 +187,13 @@ func SetUpKeepers(t *testing.T) (
 		"FiletreeParams",
 	)
 
+	n := path.Join(t.TempDir(), "filebase.db")
+	t.Log("temp filebase name: ", n)
+	d, err := sql.Open("sqlite3", n)
+	require.New(t).NoError(err)
+
 	// storage keeper initializations
-	storageKeeper := storagekeeper.NewKeeper(encCfg.Codec, skey, storParamsSubspace, bankKeeper, accountKeeper, oracleKeeper, rnsKeeper, authtypes.FeeCollectorName)
+	storageKeeper := storagekeeper.NewKeeper(encCfg.Codec, skey, storParamsSubspace, bankKeeper, accountKeeper, oracleKeeper, rnsKeeper, authtypes.FeeCollectorName, d)
 	storageKeeper.SetParams(ctx, storagemoduletypes.DefaultParams())
 
 	filetreeKeeper := keeper.NewKeeper(encCfg.Codec, fkey, memStoreKey, filParamsSubspace)

--- a/app/upgrades/v4/upgrade_test.go
+++ b/app/upgrades/v4/upgrade_test.go
@@ -104,7 +104,7 @@ func (suite *UpgradeTestKeeper) TestStorageUpgrade() {
 
 	v4.UpdateFiles(suite.ctx, suite.storageKeeper)
 
-	f := suite.storageKeeper.GetAllFileByMerkle(suite.ctx)
+	f := suite.storageKeeper.GetAllFileByMerkle()
 
 	suite.Require().Equal(1, len(f))
 }

--- a/app/upgrades/v410/commont_test.go
+++ b/app/upgrades/v410/commont_test.go
@@ -1,9 +1,8 @@
 package v410_test
 
 import (
+	"database/sql"
 	"fmt"
-	"testing"
-
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/golang/mock/gomock"
@@ -12,6 +11,10 @@ import (
 	storagekeeper "github.com/jackalLabs/canine-chain/v4/x/storage/keeper"
 	storagetestutil "github.com/jackalLabs/canine-chain/v4/x/storage/testutil"
 	storagemoduletypes "github.com/jackalLabs/canine-chain/v4/x/storage/types"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+	"path"
+	"testing"
 
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	typesparams "github.com/cosmos/cosmos-sdk/x/params/types"
@@ -76,8 +79,13 @@ func SetupStorageKeeper(t *testing.T) (
 		"StorageParams",
 	)
 
+	n := path.Join(t.TempDir(), "filebase.db")
+	t.Log("temp filebase name: ", n)
+	d, err := sql.Open("sqlite3", n)
+	require.New(t).NoError(err)
+
 	// storage keeper initializations
-	storageKeeper := storagekeeper.NewKeeper(encCfg.Codec, key, paramsSubspace, bankKeeper, accountKeeper, oracleKeeper, rnsKeeper, authtypes.FeeCollectorName)
+	storageKeeper := storagekeeper.NewKeeper(encCfg.Codec, key, paramsSubspace, bankKeeper, accountKeeper, oracleKeeper, rnsKeeper, authtypes.FeeCollectorName, d)
 	storageKeeper.SetParams(ctx, storagemoduletypes.DefaultParams())
 
 	// Register all handlers for the MegServiceRouter.
@@ -144,8 +152,13 @@ func SetUpKeepers(t *testing.T) (
 		"FiletreeParams",
 	)
 
+	n := path.Join(t.TempDir(), "filebase.db")
+	t.Log("temp filebase name: ", n)
+	d, err := sql.Open("sqlite3", n)
+	require.New(t).NoError(err)
+
 	// storage keeper initializations
-	storageKeeper := storagekeeper.NewKeeper(encCfg.Codec, skey, storParamsSubspace, bankKeeper, accountKeeper, oracleKeeper, rnsKeeper, authtypes.FeeCollectorName)
+	storageKeeper := storagekeeper.NewKeeper(encCfg.Codec, skey, storParamsSubspace, bankKeeper, accountKeeper, oracleKeeper, rnsKeeper, authtypes.FeeCollectorName, d)
 	storageKeeper.SetParams(ctx, storagemoduletypes.DefaultParams())
 
 	filetreeKeeper := keeper.NewKeeper(encCfg.Codec, fkey, memStoreKey, filParamsSubspace)

--- a/app/upgrades/v430/commont_test.go
+++ b/app/upgrades/v430/commont_test.go
@@ -1,9 +1,8 @@
 package v430_test
 
 import (
+	"database/sql"
 	"fmt"
-	"testing"
-
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/golang/mock/gomock"
@@ -12,6 +11,10 @@ import (
 	storagekeeper "github.com/jackalLabs/canine-chain/v4/x/storage/keeper"
 	storagetestutil "github.com/jackalLabs/canine-chain/v4/x/storage/testutil"
 	storagemoduletypes "github.com/jackalLabs/canine-chain/v4/x/storage/types"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+	"path"
+	"testing"
 
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	typesparams "github.com/cosmos/cosmos-sdk/x/params/types"
@@ -76,8 +79,13 @@ func SetupStorageKeeper(t *testing.T) (
 		"StorageParams",
 	)
 
+	n := path.Join(t.TempDir(), "filebase.db")
+	t.Log("temp filebase name: ", n)
+	d, err := sql.Open("sqlite3", n)
+	require.New(t).NoError(err)
+
 	// storage keeper initializations
-	storageKeeper := storagekeeper.NewKeeper(encCfg.Codec, key, paramsSubspace, bankKeeper, accountKeeper, oracleKeeper, rnsKeeper, authtypes.FeeCollectorName)
+	storageKeeper := storagekeeper.NewKeeper(encCfg.Codec, key, paramsSubspace, bankKeeper, accountKeeper, oracleKeeper, rnsKeeper, authtypes.FeeCollectorName, d)
 	storageKeeper.SetParams(ctx, storagemoduletypes.DefaultParams())
 
 	// Register all handlers for the MegServiceRouter.
@@ -144,8 +152,13 @@ func SetUpKeepers(t *testing.T) (
 		"FiletreeParams",
 	)
 
+	n := path.Join(t.TempDir(), "filebase.db")
+	t.Log("temp filebase name: ", n)
+	d, err := sql.Open("sqlite3", n)
+	require.New(t).NoError(err)
+
 	// storage keeper initializations
-	storageKeeper := storagekeeper.NewKeeper(encCfg.Codec, skey, storParamsSubspace, bankKeeper, accountKeeper, oracleKeeper, rnsKeeper, authtypes.FeeCollectorName)
+	storageKeeper := storagekeeper.NewKeeper(encCfg.Codec, skey, storParamsSubspace, bankKeeper, accountKeeper, oracleKeeper, rnsKeeper, authtypes.FeeCollectorName, d)
 	storageKeeper.SetParams(ctx, storagemoduletypes.DefaultParams())
 
 	filetreeKeeper := keeper.NewKeeper(encCfg.Codec, fkey, memStoreKey, filParamsSubspace)

--- a/app/upgrades/v440/commont_test.go
+++ b/app/upgrades/v440/commont_test.go
@@ -1,10 +1,13 @@
 package v440_test
 
 import (
+	"database/sql"
 	"fmt"
-	"testing"
-
 	mintkeeper "github.com/jackalLabs/canine-chain/v4/x/jklmint/keeper"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+	"path"
+	"testing"
 
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -78,8 +81,13 @@ func SetupStorageKeeper(t *testing.T) (
 		"StorageParams",
 	)
 
+	n := path.Join(t.TempDir(), "filebase.db")
+	t.Log("temp filebase name: ", n)
+	d, err := sql.Open("sqlite3", n)
+	require.New(t).NoError(err)
+
 	// storage keeper initializations
-	storageKeeper := storagekeeper.NewKeeper(encCfg.Codec, key, paramsSubspace, bankKeeper, accountKeeper, oracleKeeper, rnsKeeper, authtypes.FeeCollectorName)
+	storageKeeper := storagekeeper.NewKeeper(encCfg.Codec, key, paramsSubspace, bankKeeper, accountKeeper, oracleKeeper, rnsKeeper, authtypes.FeeCollectorName, d)
 	storageKeeper.SetParams(ctx, storagemoduletypes.DefaultParams())
 
 	// Register all handlers for the MegServiceRouter.
@@ -146,8 +154,13 @@ func SetUpKeepers(t *testing.T) (
 		"FiletreeParams",
 	)
 
+	n := path.Join(t.TempDir(), "filebase.db")
+	t.Log("temp filebase name: ", n)
+	d, err := sql.Open("sqlite3", n)
+	require.New(t).NoError(err)
+
 	// storage keeper initializations
-	storageKeeper := storagekeeper.NewKeeper(encCfg.Codec, skey, storParamsSubspace, bankKeeper, accountKeeper, oracleKeeper, rnsKeeper, authtypes.FeeCollectorName)
+	storageKeeper := storagekeeper.NewKeeper(encCfg.Codec, skey, storParamsSubspace, bankKeeper, accountKeeper, oracleKeeper, rnsKeeper, authtypes.FeeCollectorName, d)
 	storageKeeper.SetParams(ctx, storagemoduletypes.DefaultParams())
 
 	filetreeKeeper := keeper.NewKeeper(encCfg.Codec, fkey, memStoreKey, filParamsSubspace)

--- a/app/upgrades/v440/upgrades.go
+++ b/app/upgrades/v440/upgrades.go
@@ -49,7 +49,7 @@ func BumpInterval(ctx sdk.Context, sk *storageKeeper.Keeper) {
 	storageParams.ProofWindow = newWindow
 	sk.SetParams(ctx, storageParams)
 
-	files := sk.GetAllFileByMerkle(ctx)
+	files := sk.GetAllFileByMerkle()
 	for _, file := range files {
 		if file.ProofInterval == oldProofWindow { // updating default files to the new window
 			file.ProofInterval = newWindow

--- a/app/upgrades/v450/commont_test.go
+++ b/app/upgrades/v450/commont_test.go
@@ -1,10 +1,13 @@
 package v450_test
 
 import (
+	"database/sql"
 	"fmt"
-	"testing"
-
 	mintkeeper "github.com/jackalLabs/canine-chain/v4/x/jklmint/keeper"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+	"path"
+	"testing"
 
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -78,8 +81,13 @@ func SetupStorageKeeper(t *testing.T) (
 		"StorageParams",
 	)
 
+	n := path.Join(t.TempDir(), "filebase.db")
+	t.Log("temp filebase name: ", n)
+	d, err := sql.Open("sqlite3", n)
+	require.New(t).NoError(err)
+
 	// storage keeper initializations
-	storageKeeper := storagekeeper.NewKeeper(encCfg.Codec, key, paramsSubspace, bankKeeper, accountKeeper, oracleKeeper, rnsKeeper, authtypes.FeeCollectorName)
+	storageKeeper := storagekeeper.NewKeeper(encCfg.Codec, key, paramsSubspace, bankKeeper, accountKeeper, oracleKeeper, rnsKeeper, authtypes.FeeCollectorName, d)
 	storageKeeper.SetParams(ctx, storagemoduletypes.DefaultParams())
 
 	// Register all handlers for the MegServiceRouter.
@@ -146,8 +154,13 @@ func SetUpKeepers(t *testing.T) (
 		"FiletreeParams",
 	)
 
+	n := path.Join(t.TempDir(), "filebase.db")
+	t.Log("temp filebase name: ", n)
+	d, err := sql.Open("sqlite3", n)
+	require.New(t).NoError(err)
+
 	// storage keeper initializations
-	storageKeeper := storagekeeper.NewKeeper(encCfg.Codec, skey, storParamsSubspace, bankKeeper, accountKeeper, oracleKeeper, rnsKeeper, authtypes.FeeCollectorName)
+	storageKeeper := storagekeeper.NewKeeper(encCfg.Codec, skey, storParamsSubspace, bankKeeper, accountKeeper, oracleKeeper, rnsKeeper, authtypes.FeeCollectorName, d)
 	storageKeeper.SetParams(ctx, storagemoduletypes.DefaultParams())
 
 	filetreeKeeper := keeper.NewKeeper(encCfg.Codec, fkey, memStoreKey, filParamsSubspace)

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,10 @@ require (
 	github.com/golang/mock v1.6.0
 )
 
-require github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c // indirect
+require (
+	github.com/mattn/go-sqlite3 v1.14.27 // indirect
+	github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c // indirect
+)
 
 require (
 	cosmossdk.io/api v0.2.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -835,6 +835,8 @@ github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/mattn/go-sqlite3 v1.14.27 h1:drZCnuvf37yPfs95E5jd9s3XhdVWLal+6BOK6qrv6IU=
+github.com/mattn/go-sqlite3 v1.14.27/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=

--- a/x/storage/genesis.go
+++ b/x/storage/genesis.go
@@ -56,7 +56,7 @@ func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 	genesis := types.DefaultGenesis()
 	genesis.Params = k.GetParams(ctx)
 
-	genesis.FileList = k.GetAllFileByMerkle(ctx)
+	genesis.FileList = k.GetAllFileByMerkle()
 	genesis.ProvidersList = k.GetAllProviders(ctx)
 	genesis.PaymentInfoList = k.GetAllStoragePaymentInfo(ctx)
 	genesis.CollateralList = k.GetAllCollateral(ctx)

--- a/x/storage/keeper/common_test.go
+++ b/x/storage/keeper/common_test.go
@@ -1,12 +1,15 @@
 package keeper_test
 
 import (
+	"database/sql"
 	"fmt"
-	"testing"
-
 	oracletypes "github.com/jackalLabs/canine-chain/v4/x/oracle/types"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	tmtime "github.com/tendermint/tendermint/types/time"
+	"path"
+	"testing"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 
@@ -71,8 +74,13 @@ func setupStorageKeeper(t *testing.T) (
 		"StorageParams",
 	)
 
+	n := path.Join(t.TempDir(), "filebase.db")
+	t.Log("temp filebase name: ", n)
+	d, err := sql.Open("sqlite3", n)
+	require.New(t).NoError(err)
+
 	// storage keeper initializations
-	storageKeeper := keeper.NewKeeper(encCfg.Codec, key, paramsSubspace, bankKeeper, accountKeeper, oracleKeeper, rnsKeeper, authtypes.FeeCollectorName)
+	storageKeeper := keeper.NewKeeper(encCfg.Codec, key, paramsSubspace, bankKeeper, accountKeeper, oracleKeeper, rnsKeeper, authtypes.FeeCollectorName, d)
 	storageKeeper.SetParams(ctx, types.DefaultParams())
 
 	// Register all handlers for the MegServiceRouter.

--- a/x/storage/keeper/filebase.go
+++ b/x/storage/keeper/filebase.go
@@ -1,0 +1,47 @@
+package keeper
+
+import "database/sql"
+
+// CreateTablesIfNotExist initializes the file database schema
+func CreateTablesIfNotExist(db *sql.DB) error {
+	// Create unified_files table if it doesn't exist
+	_, err := db.Exec(`
+	CREATE TABLE IF NOT EXISTS unified_files (
+		merkle BLOB NOT NULL,
+		owner TEXT NOT NULL,
+		start INTEGER NOT NULL,
+		expires INTEGER NOT NULL,
+		file_size INTEGER NOT NULL,
+		proof_interval INTEGER NOT NULL,
+		proof_type INTEGER NOT NULL,
+		max_proofs INTEGER NOT NULL,
+		note TEXT,
+		PRIMARY KEY (merkle, owner, start)
+	)`)
+	if err != nil {
+		return err
+	}
+
+	// Create proofs table if it doesn't exist
+	_, err = db.Exec(`
+	CREATE TABLE IF NOT EXISTS proofs (
+		file_merkle BLOB NOT NULL,
+		file_owner TEXT NOT NULL,
+		file_start INTEGER NOT NULL,
+		proof TEXT NOT NULL,
+		PRIMARY KEY (file_merkle, file_owner, file_start, proof),
+		FOREIGN KEY (file_merkle, file_owner, file_start) 
+			REFERENCES unified_files (merkle, owner, start) ON DELETE CASCADE
+	)`)
+	if err != nil {
+		return err
+	}
+
+	// Create index for expires column if it doesn't exist
+	_, err = db.Exec(`
+	CREATE INDEX IF NOT EXISTS idx_unified_files_expires 
+	ON unified_files (expires)
+	`)
+
+	return err
+}

--- a/x/storage/keeper/files_old.go
+++ b/x/storage/keeper/files_old.go
@@ -1,0 +1,172 @@
+package keeper
+
+import (
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/jackalLabs/canine-chain/v4/x/storage/types"
+)
+
+// Deprecated: This is simply a utility function to facilitate a migration
+func (k Keeper) setFilePrimaryOld(ctx sdk.Context, file types.UnifiedFile) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.FilePrimaryKeyPrefix))
+	b := k.cdc.MustMarshal(&file)
+	store.Set(types.FilesPrimaryKey(
+		file.Merkle,
+		file.Owner,
+		file.Start,
+	), b)
+}
+
+// SetFileOld set a specific File in the store from its index
+//
+// Deprecated: This is simply a utility function to facilitate a migration
+func (k Keeper) SetFileOld(ctx sdk.Context, file types.UnifiedFile) {
+	k.setFilePrimaryOld(ctx, file)
+}
+
+// GetFileOld returns a File from its index
+//
+// Deprecated: This is simply a utility function to facilitate a migration
+func (k Keeper) GetFileOld(
+	ctx sdk.Context,
+	merkle []byte,
+	owner string,
+	start int64,
+) (val types.UnifiedFile, found bool) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.FilePrimaryKeyPrefix))
+
+	b := store.Get(types.FilesPrimaryKey(
+		merkle, owner, start,
+	))
+	if b == nil {
+		return val, false
+	}
+
+	k.cdc.MustUnmarshal(b, &val)
+	return val, true
+}
+
+// Deprecated: This is simply a utility function to facilitate a migration
+func (k Keeper) removeFilePrimaryOld(
+	ctx sdk.Context,
+	merkle []byte,
+	owner string,
+	start int64,
+) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.FilePrimaryKeyPrefix))
+	store.Delete(types.FilesPrimaryKey(
+		merkle,
+		owner,
+		start,
+	))
+}
+
+// RemoveFileOld removes a File from the store
+//
+// Deprecated: This is simply a utility function to facilitate a migration
+func (k Keeper) RemoveFileOld(
+	ctx sdk.Context,
+	merkle []byte,
+	owner string,
+	start int64,
+) {
+	file, found := k.GetFileOld(ctx, merkle, owner, start)
+	if !found {
+		return
+	}
+
+	for _, proof := range file.Proofs { // deleting all the associated proofs too
+		k.RemoveProofWithBuiltKey(ctx, []byte(proof))
+	}
+
+	k.removeFilePrimaryOld(ctx, merkle, owner, start)
+}
+
+// GetAllFileByMerkleOld returns all File
+//
+// Deprecated: This is simply a utility function to facilitate a migration
+func (k Keeper) GetAllFileByMerkleOld(ctx sdk.Context) (list []types.UnifiedFile) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.FilePrimaryKeyPrefix))
+	iterator := sdk.KVStorePrefixIterator(store, []byte{})
+
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		var val types.UnifiedFile
+		k.cdc.MustUnmarshal(iterator.Value(), &val)
+		list = append(list, val)
+	}
+
+	return
+}
+
+// IterateFilesByMerkleOld iterates through every file
+//
+// Deprecated: This is simply a utility function to facilitate a migration
+func (k Keeper) IterateFilesByMerkleOld(ctx sdk.Context, reverse bool, fn func(key []byte, val []byte) bool) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.FilePrimaryKeyPrefix))
+
+	var iterator storetypes.Iterator
+	if reverse {
+		iterator = sdk.KVStoreReversePrefixIterator(store, []byte{})
+	} else {
+		iterator = sdk.KVStorePrefixIterator(store, []byte{})
+	}
+
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		b := fn(iterator.Key(), iterator.Value())
+		if b {
+			return
+		}
+	}
+}
+
+// IterateAndParseFilesByMerkleOld iterates through every file and parses them for you
+//
+// Deprecated: This is simply a utility function to facilitate a migration
+func (k Keeper) IterateAndParseFilesByMerkleOld(ctx sdk.Context, reverse bool, fn func(key []byte, val types.UnifiedFile) bool) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.FilePrimaryKeyPrefix))
+
+	var iterator storetypes.Iterator
+	if reverse {
+		iterator = sdk.KVStoreReversePrefixIterator(store, []byte{})
+	} else {
+		iterator = sdk.KVStorePrefixIterator(store, []byte{})
+	}
+
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		val := iterator.Value()
+		var file types.UnifiedFile
+		if err := k.cdc.Unmarshal(val, &file); err != nil {
+			return
+		}
+
+		b := fn(iterator.Key(), file)
+		if b {
+			return
+		}
+	}
+}
+
+// GetAllFilesWithMerkleOld returns all Files that start with a specific merkle
+//
+// Deprecated: This is simply a utility function to facilitate a migration
+func (k Keeper) GetAllFilesWithMerkleOld(ctx sdk.Context, merkle []byte) (list []types.UnifiedFile) {
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.FilesMerklePrefix(merkle))
+	iterator := sdk.KVStorePrefixIterator(store, nil)
+
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		var val types.UnifiedFile
+		k.cdc.MustUnmarshal(iterator.Value(), &val)
+		list = append(list, val)
+	}
+
+	return
+}

--- a/x/storage/keeper/grpc_query_active_deals_test.go
+++ b/x/storage/keeper/grpc_query_active_deals_test.go
@@ -109,7 +109,7 @@ func (suite *KeeperTestSuite) TestAllFiles() {
 
 	merkle := []byte("merkle")
 
-	suite.storageKeeper.SetFile(suite.ctx, types.UnifiedFile{
+	err = suite.storageKeeper.SetFile(suite.ctx, types.UnifiedFile{
 		Merkle:        merkle,
 		Owner:         testAccount,
 		Start:         0,
@@ -121,6 +121,7 @@ func (suite *KeeperTestSuite) TestAllFiles() {
 		MaxProofs:     3,
 		Note:          "test",
 	})
+	suite.Require().NoError(err)
 
 	pg := query.PageRequest{
 		Offset:  0,
@@ -131,6 +132,8 @@ func (suite *KeeperTestSuite) TestAllFiles() {
 		Pagination: &pg,
 	})
 	suite.Require().NoError(err)
+
+	suite.Require().Equal(uint64(1), res.Pagination.Total)
 
 	suite.Require().Equal(1, len(res.Files))
 
@@ -177,7 +180,7 @@ func (suite *KeeperTestSuite) TestOpenFiles() {
 	for i := 0; i < count; i++ {
 		merkle := []byte(fmt.Sprintf("%dmerkle%d", i, i))
 
-		suite.storageKeeper.SetFile(suite.ctx, types.UnifiedFile{
+		err = suite.storageKeeper.SetFile(suite.ctx, types.UnifiedFile{
 			Merkle:        merkle,
 			Owner:         testAccount,
 			Start:         0,
@@ -189,6 +192,7 @@ func (suite *KeeperTestSuite) TestOpenFiles() {
 			MaxProofs:     3,
 			Note:          "{}",
 		})
+		suite.Require().NoError(err)
 	}
 
 	pg := query.PageRequest{
@@ -245,7 +249,7 @@ func (suite *KeeperTestSuite) TestFileNotes() {
 	b, err := json.Marshal(m)
 	suite.Require().NoError(err)
 
-	suite.storageKeeper.SetFile(suite.ctx, types.UnifiedFile{
+	err = suite.storageKeeper.SetFile(suite.ctx, types.UnifiedFile{
 		Merkle:        merkle,
 		Owner:         testAccount,
 		Start:         0,
@@ -257,6 +261,7 @@ func (suite *KeeperTestSuite) TestFileNotes() {
 		MaxProofs:     3,
 		Note:          string(b),
 	})
+	suite.Require().NoError(err)
 
 	bk := "terribleKey"
 	bv := sdk.NewDec(46)
@@ -267,7 +272,7 @@ func (suite *KeeperTestSuite) TestFileNotes() {
 
 	bmerkle := []byte("badmerkle")
 
-	suite.storageKeeper.SetFile(suite.ctx, types.UnifiedFile{
+	err = suite.storageKeeper.SetFile(suite.ctx, types.UnifiedFile{
 		Merkle:        bmerkle,
 		Owner:         testAccount,
 		Start:         0,
@@ -279,6 +284,7 @@ func (suite *KeeperTestSuite) TestFileNotes() {
 		MaxProofs:     3,
 		Note:          string(bb),
 	})
+	suite.Require().NoError(err)
 
 	pg := query.PageRequest{
 		Offset:  0,
@@ -377,7 +383,8 @@ func (suite *KeeperTestSuite) TestProofsByAddress() {
 		Note:          string(b),
 	}
 
-	suite.storageKeeper.SetFile(suite.ctx, file)
+	err = suite.storageKeeper.SetFile(suite.ctx, file)
+	suite.Require().NoError(err)
 
 	pg := query.PageRequest{
 		Offset:  0,

--- a/x/storage/keeper/keeper.go
+++ b/x/storage/keeper/keeper.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"database/sql"
 	"fmt"
 
 	"github.com/tendermint/tendermint/libs/log"
@@ -13,15 +14,16 @@ import (
 
 type (
 	Keeper struct {
-		cdc           codec.BinaryCodec
-		storeKey      sdk.StoreKey
-		paramStore    paramtypes.Subspace
-		bankKeeper    types.BankKeeper
-		accountKeeper types.AccountKeeper
-		oracleKeeper  types.OracleKeeper
-		rnsKeeper     types.RnsKeeper
-
+		cdc              codec.BinaryCodec
+		storeKey         sdk.StoreKey
+		paramStore       paramtypes.Subspace
+		bankKeeper       types.BankKeeper
+		accountKeeper    types.AccountKeeper
+		oracleKeeper     types.OracleKeeper
+		rnsKeeper        types.RnsKeeper
 		feeCollectorName string
+
+		filebase *sql.DB
 	}
 )
 
@@ -34,10 +36,16 @@ func NewKeeper(
 	oracleKeeper types.OracleKeeper,
 	rnsKeeper types.RnsKeeper,
 	feeCollectorName string,
+	filebase *sql.DB,
 ) *Keeper {
 	// set KeyTable if it has not already been set
 	if !ps.HasKeyTable() {
 		ps = ps.WithKeyTable(types.ParamKeyTable())
+	}
+
+	err := CreateTablesIfNotExist(filebase)
+	if err != nil {
+		panic(err)
 	}
 
 	return &Keeper{
@@ -49,6 +57,7 @@ func NewKeeper(
 		oracleKeeper:     oracleKeeper,
 		rnsKeeper:        rnsKeeper,
 		feeCollectorName: feeCollectorName,
+		filebase:         filebase,
 	}
 }
 

--- a/x/storage/keeper/msg_server_buy_storage.go
+++ b/x/storage/keeper/msg_server_buy_storage.go
@@ -106,7 +106,6 @@ func (k msgServer) BuyStorage(goCtx context.Context, msg *types.MsgBuyStorage) (
 
 	pol := sdk.NewDec(params.PolRatio).QuoInt64(100)
 	discount := sdk.NewDec(0)
-	fmt.Printf("POL: %d / %f\n", params.PolRatio, pol.MustFloat64())
 	if referred {
 
 		p := toPay.Amount.ToDec()
@@ -145,10 +144,7 @@ func (k msgServer) BuyStorage(goCtx context.Context, msg *types.MsgBuyStorage) (
 	k.SetStoragePaymentInfo(ctx, spi)
 
 	refDec := sdk.NewDec(params.ReferralCommission).QuoInt64(100)
-	fmt.Printf("RATIOS!\nref: %d\npol: %d\ndiscount: %d\n", refDec.MulInt64(100).TruncateInt64(), pol.MulInt64(100).TruncateInt64(), discount.MulInt64(100).TruncateInt64())
 	spr := sdk.NewDec(1).Sub(refDec).Sub(pol).Sub(discount) // whatever is left from pol and referrals
-
-	fmt.Printf("storageprovider ratio: %d\n", spr.MulInt64(100).TruncateInt().Int64())
 
 	storageProviderCut := toPay.Amount.ToDec().Mul(spr)
 	spcToken := sdk.NewCoin(toPay.Denom, storageProviderCut.TruncateInt())

--- a/x/storage/keeper/providers.go
+++ b/x/storage/keeper/providers.go
@@ -87,24 +87,16 @@ func (k Keeper) GetActiveProviders(ctx sdk.Context, filterAddress string) []type
 // GetRandomizedProviders returns a list of providers in a random order
 func (k Keeper) GetRandomizedProviders(ctx sdk.Context) []types.Providers {
 	providers := k.GetAllProviders(ctx)
-
 	size := len(providers)
 
-	rounds := Rounds * size
-
-	i64Size := int64(size)
-
-	r := rand.NewRand() // creating a new random generator to ensure no interference
-
+	// Use Fisher-Yates algorithm - O(n) complexity
+	r := rand.NewRand()
 	r.Seed(ctx.BlockHeight())
 
-	for i := 0; i < rounds; i++ {
-		x := r.Int63n(i64Size)
-		y := r.Int63n(i64Size)
-
-		providers[x], providers[y] = providers[y], providers[x]
+	for i := size - 1; i > 0; i-- {
+		j := r.Int63n(int64(i + 1))
+		providers[i], providers[j] = providers[j], providers[i]
 	}
-
 	return providers
 }
 

--- a/x/storage/types/proof_loader.go
+++ b/x/storage/types/proof_loader.go
@@ -12,7 +12,7 @@ type ProofLoader interface {
 		ctx sdk.Context,
 		key []byte,
 	)
-	SetFile(ctx sdk.Context, File UnifiedFile)
+	SetFile(ctx sdk.Context, File UnifiedFile) error
 }
 
 func (p *FileProof) Save(ctx sdk.Context, k ProofLoader) {


### PR DESCRIPTION
Introducing our newest fight against the Cosmos SDK! The IAVL tree that manages to KV store (and helps with consensus) is massively limiting our queries because of how much iteration we do through these stores. Instead we sideload it and replace it with a dedicated sqlite database (technically not part of consensus now)!

This dedicated database is called our "filebase" (file database 🙄). It lets us query files much faster and filter data without needing to protobuf marshal and unmarshal every time we open it. Sqlite also comes with some niceties such as json extraction allowing us to speed up our note system.