### PR TITLE
Update golangci-lint and fix lint issues

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -20,7 +20,7 @@ jobs:
           go-version: 1.23
       - uses: actions/checkout@v4.2.2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,35 +1,47 @@
+version: "2"
 run:
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 10m
   tests: true
-
 linters:
-  disable-all: true
+  default: none
   enable:
     - bodyclose
     - dogsled
     - errcheck
     - goconst
     - gocritic
-    - gofumpt
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - nakedret
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
-    - unused
     - unparam
-
-linters-settings:
-  gosec:
-    excludes:
-      - G404
-      - G115
-
+    - unused
+  settings:
+    gosec:
+      excludes:
+        - G404
+        - G115
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   max-issues-per-linter: 0
+formatters:
+  enable:
+    - gofumpt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/app/app.go
+++ b/app/app.go
@@ -442,7 +442,7 @@ func NewJackalApp(
 	app.authzKeeper = authzkeeper.NewKeeper(
 		keys[authzkeeper.StoreKey],
 		appCodec,
-		app.BaseApp.MsgServiceRouter(),
+		app.MsgServiceRouter(),
 	)
 	app.feeGrantKeeper = feegrantkeeper.NewKeeper(
 		appCodec,
@@ -716,7 +716,7 @@ func NewJackalApp(
 		genutil.NewAppModule(
 			app.AccountKeeper,
 			app.stakingKeeper,
-			app.BaseApp.DeliverTx,
+			app.DeliverTx,
 			encodingConfig.TxConfig,
 		),
 		auth.NewAppModule(appCodec, app.AccountKeeper, nil),
@@ -1023,7 +1023,7 @@ func NewJackalApp(
 		if err := app.LoadLatestVersion(); err != nil {
 			tmos.Exit(fmt.Sprintf("failed to load latest version: %s", err))
 		}
-		ctx := app.BaseApp.NewUncachedContext(true, tmproto.Header{})
+		ctx := app.NewUncachedContext(true, tmproto.Header{})
 
 		// Initialize pinned codes in wasmvm as they are not persisted there
 		if err := app.wasmKeeper.InitializePinnedCodes(ctx); err != nil {

--- a/app/app.go
+++ b/app/app.go
@@ -1123,12 +1123,12 @@ func (app *JackalApp) RegisterAPIRoutes(apiSvr *api.Server, apiConfig config.API
 
 // RegisterTxService implements the Application.RegisterTxService method.
 func (app *JackalApp) RegisterTxService(clientCtx client.Context) {
-	authtx.RegisterTxService(app.BaseApp.GRPCQueryRouter(), clientCtx, app.BaseApp.Simulate, app.InterfaceRegistry)
+	authtx.RegisterTxService(app.GRPCQueryRouter(), clientCtx, app.Simulate, app.InterfaceRegistry)
 }
 
 // RegisterTendermintService implements the Application.RegisterTendermintService method.
 func (app *JackalApp) RegisterTendermintService(clientCtx client.Context) {
-	tmservice.RegisterTendermintService(app.BaseApp.GRPCQueryRouter(), clientCtx, app.InterfaceRegistry)
+	tmservice.RegisterTendermintService(app.GRPCQueryRouter(), clientCtx, app.InterfaceRegistry)
 }
 
 func (app *JackalApp) AppCodec() codec.Codec {

--- a/app/export.go
+++ b/app/export.go
@@ -40,7 +40,7 @@ func (app *JackalApp) ExportAppStateAndValidators(
 		AppState:        appState,
 		Validators:      validators,
 		Height:          height,
-		ConsensusParams: app.BaseApp.GetConsensusParams(ctx),
+		ConsensusParams: app.GetConsensusParams(ctx),
 	}, err
 }
 
@@ -49,12 +49,7 @@ func (app *JackalApp) ExportAppStateAndValidators(
 //
 //	in favour of export at a block height
 func (app *JackalApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []string) {
-	applyAllowedAddrs := false
-
-	// check if there is a allowed address list
-	if len(jailAllowedAddrs) > 0 {
-		applyAllowedAddrs = true
-	}
+	applyAllowedAddrs := len(jailAllowedAddrs) > 0
 
 	allowedAddrsMap := make(map[string]bool)
 

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -279,7 +279,7 @@ func TestAddr(addr string, bech string) (sdk.AccAddress, error) {
 
 // CheckBalance checks the balance of an account.
 func CheckBalance(t *testing.T, app *JackalApp, addr sdk.AccAddress, balances sdk.Coins) {
-	ctxCheck := app.BaseApp.NewContext(true, tmproto.Header{})
+	ctxCheck := app.NewContext(true, tmproto.Header{})
 	require.True(t, balances.IsEqual(app.BankKeeper.GetAllBalances(ctxCheck, addr)))
 }
 

--- a/app/upgrades/v4/upgrade_test.go
+++ b/app/upgrades/v4/upgrade_test.go
@@ -20,10 +20,10 @@ func (suite *UpgradeTestKeeper) TestUpgrade() {
 
 	fidMerkleMap := make(map[string][]byte)
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		n := rand.Int63()
 		s := sha256.New()
-		s.Write([]byte(fmt.Sprintf("%d", n)))
+		fmt.Fprintf(s, "%d", n)
 		d := s.Sum(nil)
 		conv, err := bech32.ConvertBits(d, 8, 5, true)
 		suite.Require().NoError(err)

--- a/x/filetree/client/cli/query_files.go
+++ b/x/filetree/client/cli/query_files.go
@@ -103,7 +103,7 @@ func CmdShowFileFromPath() *cobra.Command {
 
 			// make the full OwnerAddress
 			H := sha256.New()
-			H.Write([]byte(fmt.Sprintf("o%s%s", merklePath, accountHash)))
+			fmt.Fprintf(H, "o%s%s", merklePath, accountHash)
 			Hash := H.Sum(nil)
 			ownerAddress := fmt.Sprintf("%x", Hash)
 

--- a/x/filetree/client/cli/query_get_keys.go
+++ b/x/filetree/client/cli/query_get_keys.go
@@ -44,7 +44,7 @@ func CmdGetKeys() *cobra.Command {
 			accountHash := fmt.Sprintf("%x", hash)
 
 			H := sha256.New()
-			H.Write([]byte(fmt.Sprintf("o%s%s", merklePath, accountHash))) // May not need this in future
+			fmt.Fprintf(H, "o%s%s", merklePath, accountHash) // May not need this in future
 			Hash := H.Sum(nil)
 			ownerString := fmt.Sprintf("%x", Hash) // Make the owner string to find the file
 

--- a/x/filetree/client/cli/tx_add_editors.go
+++ b/x/filetree/client/cli/tx_add_editors.go
@@ -92,7 +92,7 @@ func CmdAddEditors() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				logger.Println("hex message is", hexMessage)
+				logger.Println("hex message is", string(hexMessage))
 
 				// May need to use "clientCtx.from?"
 				ownerPrivateKey, err := MakePrivateKey(clientCtx)

--- a/x/filetree/client/cli/tx_make_root.go
+++ b/x/filetree/client/cli/tx_make_root.go
@@ -39,7 +39,7 @@ func CmdMakeRootV2() *cobra.Command {
 			// We include the creator of this root as an editor so that they can add children--folders or files
 
 			h := sha256.New()
-			h.Write([]byte(fmt.Sprintf("e%s%s", trackingNumber, clientCtx.GetFromAddress().String())))
+			fmt.Fprintf(h, "e%s%s", trackingNumber, clientCtx.GetFromAddress().String())
 			hash := h.Sum(nil)
 
 			addressString := fmt.Sprintf("%x", hash)

--- a/x/filetree/client/cli/tx_post_file.go
+++ b/x/filetree/client/cli/tx_post_file.go
@@ -64,7 +64,7 @@ func CmdPostFile() *cobra.Command {
 				}
 
 				h := sha256.New()
-				h.Write([]byte(fmt.Sprintf("v%s%s", trackingNumber, v)))
+				fmt.Fprintf(h, "v%s%s", trackingNumber, v)
 				hash := h.Sum(nil)
 				addressString := fmt.Sprintf("%x", hash)
 
@@ -82,7 +82,7 @@ func CmdPostFile() *cobra.Command {
 				}
 
 				h := sha256.New()
-				h.Write([]byte(fmt.Sprintf("e%s%s", trackingNumber, v)))
+				fmt.Fprintf(h, "e%s%s", trackingNumber, v)
 				hash := h.Sum(nil)
 				addressString := fmt.Sprintf("%x", hash)
 

--- a/x/filetree/client/cli/utils.go
+++ b/x/filetree/client/cli/utils.go
@@ -51,7 +51,7 @@ func MakeOwnerAddress(merklePath string, user string) string {
 
 	// h1 is so named as to differentiate it from h above--else compiler complains
 	h1 := sha256.New()
-	h1.Write([]byte(fmt.Sprintf("o%s%s", merklePath, accountHash)))
+	fmt.Fprintf(h1, "o%s%s", merklePath, accountHash)
 	hash1 := h1.Sum(nil)
 	ownerAddress := fmt.Sprintf("%x", hash1)
 

--- a/x/filetree/keeper/access.go
+++ b/x/filetree/keeper/access.go
@@ -63,7 +63,7 @@ func IsOwner(file types.Files, user string) bool {
 
 	// h1 is so named as to differentiate it from h above--else compiler complains
 	h1 := sha256.New()
-	h1.Write([]byte(fmt.Sprintf("o%s%s", merklePath, accountHash)))
+	fmt.Fprintf(h1, "o%s%s", merklePath, accountHash)
 	hash1 := h1.Sum(nil)
 	ownerAddress := fmt.Sprintf("%x", hash1)
 
@@ -72,7 +72,7 @@ func IsOwner(file types.Files, user string) bool {
 
 func MakeViewerAddress(trackingNumber string, user string) string {
 	h := sha256.New()
-	h.Write([]byte(fmt.Sprintf("v%s%s", trackingNumber, user)))
+	fmt.Fprintf(h, "v%s%s", trackingNumber, user)
 	hash := h.Sum(nil)
 	addressString := fmt.Sprintf("%x", hash)
 
@@ -81,7 +81,7 @@ func MakeViewerAddress(trackingNumber string, user string) string {
 
 func MakeEditorAddress(trackingNumber string, user string) string {
 	h := sha256.New()
-	h.Write([]byte(fmt.Sprintf("e%s%s", trackingNumber, user)))
+	fmt.Fprintf(h, "e%s%s", trackingNumber, user)
 	hash := h.Sum(nil)
 	addressString := fmt.Sprintf("%x", hash)
 
@@ -93,7 +93,7 @@ func MakeOwnerAddress(merklePath string, user string) string {
 	// make sure that user was already hex(hashed) before it was passed into
 	// this function
 	h := sha256.New()
-	h.Write([]byte(fmt.Sprintf("o%s%s", merklePath, user)))
+	fmt.Fprintf(h, "o%s%s", merklePath, user)
 	hash := h.Sum(nil)
 	ownerAddress := fmt.Sprintf("%x", hash)
 

--- a/x/filetree/keeper/access.go
+++ b/x/filetree/keeper/access.go
@@ -21,7 +21,7 @@ func HasViewingAccess(file types.Files, user string) (bool, error) {
 	}
 
 	h := sha256.New()
-	h.Write([]byte(fmt.Sprintf("v%s%s", trackingNumber, user)))
+	fmt.Fprintf(h, "v%s%s", trackingNumber, user)
 	hash := h.Sum(nil)
 
 	addressString := fmt.Sprintf("%x", hash)
@@ -43,7 +43,7 @@ func HasEditAccess(file types.Files, user string) (bool, error) {
 	}
 
 	h := sha256.New()
-	h.Write([]byte(fmt.Sprintf("e%s%s", trackingNumber, user)))
+	fmt.Fprintf(h, "e%s%s", trackingNumber, user)
 	hash := h.Sum(nil)
 
 	addressString := fmt.Sprintf("%x", hash)

--- a/x/filetree/keeper/access_test.go
+++ b/x/filetree/keeper/access_test.go
@@ -46,7 +46,7 @@ func FuzzMakeEditorAddress(f *testing.F) {
 		out := keeper.MakeEditorAddress(track, user)
 
 		eh := sha256.New()
-		eh.Write([]byte(fmt.Sprintf("e%s%s", track, user)))
+		fmt.Fprintf(eh, "e%s%s", track, user)
 		expHash := fmt.Sprintf("%x", eh.Sum(nil))
 
 		if out != expHash {
@@ -87,7 +87,7 @@ func FuzzMakeOwnerAddress(f *testing.F) {
 		out := keeper.MakeOwnerAddress(track, user)
 
 		eh := sha256.New()
-		eh.Write([]byte(fmt.Sprintf("o%s%s", track, user)))
+		fmt.Fprintf(eh, "o%s%s", track, user)
 		expHash := fmt.Sprintf("%x", eh.Sum(nil))
 
 		if out != expHash {
@@ -128,7 +128,7 @@ func FuzzMakeViewerAddress(f *testing.F) {
 		out := keeper.MakeViewerAddress(track, user)
 
 		eh := sha256.New()
-		eh.Write([]byte(fmt.Sprintf("v%s%s", track, user)))
+		fmt.Fprintf(eh, "v%s%s", track, user)
 		expHash := fmt.Sprintf("%x", eh.Sum(nil))
 
 		if out != expHash {
@@ -167,7 +167,7 @@ func (suite *KeeperTestSuite) TestMakeViewerAddress() {
 
 		suite.Run(fmt.Sprintf("trackingNum: %s, user: %s", tc.trackingNum, tc.user), func() {
 			h := sha256.New()
-			h.Write([]byte(fmt.Sprintf("v%s%s", tc.trackingNum, tc.user)))
+			fmt.Fprintf(h, "v%s%s", tc.trackingNum, tc.user)
 			hash := h.Sum(nil)
 
 			out := keeper.MakeViewerAddress(tc.trackingNum, tc.user)
@@ -216,7 +216,7 @@ func (suite *KeeperTestSuite) TestIsOwner() {
 
 				// h1 is so named as to differentiate it from h above--else compiler complains
 				h1 := sha256.New()
-				h1.Write([]byte(fmt.Sprintf("o%s%s", tc.addr, accountHash)))
+				fmt.Fprintf(h1, "o%s%s", tc.addr, accountHash)
 				hash1 := h1.Sum(nil)
 				tc.owner = fmt.Sprintf("%x", hash1)
 			}
@@ -280,7 +280,7 @@ func FuzzHasEditAccess(f *testing.F) {
 			}
 
 			h := sha256.New()
-			h.Write([]byte(fmt.Sprintf("e%s%s", track, user)))
+			fmt.Fprintf(h, "e%s%s", track, user)
 			hash := h.Sum(nil)
 
 			jeacc := make(map[string]string)
@@ -337,7 +337,7 @@ func (suite *KeeperTestSuite) TestHasEditAccess() {
 			if tc.editAccess == "" {
 				// Construct new editor
 				h := sha256.New()
-				h.Write([]byte(fmt.Sprintf("e%s%s", tc.trackingNum, tc.user)))
+				fmt.Fprintf(h, "e%s%s", tc.trackingNum, tc.user)
 				hash := h.Sum(nil)
 
 				jeacc := make(map[string]string)
@@ -405,7 +405,7 @@ func (suite *KeeperTestSuite) TestHasViewingAccess() {
 			if tc.viewingAccess == "" {
 				// Construct new editor
 				h := sha256.New()
-				h.Write([]byte(fmt.Sprintf("v%s%s", tc.trackingNum, tc.user)))
+				fmt.Fprintf(h, "v%s%s", tc.trackingNum, tc.user)
 				hash := h.Sum(nil)
 
 				jvacc := make(map[string]string)

--- a/x/filetree/types/test_helpers.go
+++ b/x/filetree/types/test_helpers.go
@@ -119,7 +119,7 @@ func MakeOwnerAddress(merklePath string, user string) string {
 	// make sure that user was already hex(hashed) before it was passed into
 	// this function
 	h := sha256.New()
-	h.Write([]byte(fmt.Sprintf("o%s%s", merklePath, user)))
+	fmt.Fprintf(h, "o%s%s", merklePath, user)
 	hash := h.Sum(nil)
 	ownerAddress := fmt.Sprintf("%x", hash)
 
@@ -155,7 +155,7 @@ func MakeEditorAccessMap(trackingNumber string, editorIDs []string, aesKey strin
 
 	for _, v := range editorIDs {
 		h := sha256.New()
-		h.Write([]byte(fmt.Sprintf("e%s%s", trackingNumber, v)))
+		fmt.Fprintf(h, "e%s%s", trackingNumber, v)
 		hash := h.Sum(nil)
 		addressString := fmt.Sprintf("%x", hash)
 
@@ -176,7 +176,7 @@ func MakeViewerAccessMap(trackingNumber string, viewerIDs []string, aesKey strin
 
 	for _, v := range viewerIDs {
 		h := sha256.New()
-		h.Write([]byte(fmt.Sprintf("v%s%s", trackingNumber, v)))
+		fmt.Fprintf(h, "v%s%s", trackingNumber, v)
 		hash := h.Sum(nil)
 		addressString := fmt.Sprintf("%x", hash)
 

--- a/x/jklmint/keeper/grpc_query_params_test.go
+++ b/x/jklmint/keeper/grpc_query_params_test.go
@@ -22,7 +22,7 @@ type MintTestSuite struct {
 
 func (suite *MintTestSuite) SetupTest() {
 	app := setup(false)
-	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+	ctx := app.NewContext(false, tmproto.Header{})
 
 	queryHelper := baseapp.NewQueryServerTestHelper(ctx, app.InterfaceRegistry)
 	types.RegisterQueryServer(queryHelper, app.MintKeeper)

--- a/x/jklmint/keeper/integration_test.go
+++ b/x/jklmint/keeper/integration_test.go
@@ -22,7 +22,7 @@ import (
 func createTestApp(isCheckTx bool) (*jklapp.JackalApp, sdk.Context) {
 	app := setup(isCheckTx)
 
-	ctx := app.BaseApp.NewContext(isCheckTx, tmproto.Header{})
+	ctx := app.NewContext(isCheckTx, tmproto.Header{})
 
 	app.MintKeeper.SetParams(ctx, types.DefaultParams())
 

--- a/x/rns/keeper/names.go
+++ b/x/rns/keeper/names.go
@@ -140,11 +140,7 @@ func (k Keeper) CheckExistence(ctx sdk.Context) bool {
 		}
 		i++
 	}
-	exist := false
-	if i > 0 {
-		exist = true
-	}
-	return exist
+	return i > 0
 }
 
 func (k Keeper) Resolve(ctx sdk.Context, name string) (sdk.AccAddress, error) {

--- a/x/storage/keeper/gauges.go
+++ b/x/storage/keeper/gauges.go
@@ -12,7 +12,7 @@ import (
 
 func (k Keeper) NewGauge(ctx sdk.Context, coins sdk.Coins, end time.Time) types.PaymentGauge {
 	h := sha256.New()
-	h.Write([]byte(fmt.Sprintf("%d--%d--%s", ctx.BlockHeight(), end.UnixMicro(), coins.String())))
+	fmt.Fprintf(h, "%d--%d--%s", ctx.BlockHeight(), end.UnixMicro(), coins.String())
 	id := h.Sum(nil)
 
 	pg := types.PaymentGauge{

--- a/x/storage/keeper/grpc_query_active_deals_test.go
+++ b/x/storage/keeper/grpc_query_active_deals_test.go
@@ -68,7 +68,7 @@ func setup(isCheckTx bool) *jklapp.JackalApp {
 
 func (suite *KeeperTestSuite) SetupTest() {
 	app := setup(false)
-	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+	ctx := app.NewContext(false, tmproto.Header{})
 
 	queryHelper := baseapp.NewQueryServerTestHelper(ctx, app.InterfaceRegistry)
 	types.RegisterQueryServer(queryHelper, app.StorageKeeper)

--- a/x/storage/keeper/msg_server_buy_storage.go
+++ b/x/storage/keeper/msg_server_buy_storage.go
@@ -99,9 +99,7 @@ func (k msgServer) BuyStorage(goCtx context.Context, msg *types.MsgBuyStorage) (
 	referred := false
 	refAcc, err := k.rnsKeeper.Resolve(ctx, msg.Referral)
 	if err == nil {
-		if !(refAcc.String() == msg.Creator) {
-			referred = true
-		}
+		referred = refAcc.String() != msg.Creator
 	}
 
 	pol := sdk.NewDec(params.PolRatio).QuoInt64(100)

--- a/x/storage/keeper/msg_server_file_delete.go
+++ b/x/storage/keeper/msg_server_file_delete.go
@@ -11,7 +11,7 @@ import (
 func (k msgServer) DeleteFile(goCtx context.Context, msg *types.MsgDeleteFile) (*types.MsgDeleteFileResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	k.Keeper.RemoveFile(ctx, msg.Merkle, msg.Creator, msg.Start)
+	k.RemoveFile(ctx, msg.Merkle, msg.Creator, msg.Start)
 
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(

--- a/x/storage/keeper/msg_server_report.go
+++ b/x/storage/keeper/msg_server_report.go
@@ -57,7 +57,7 @@ func (k Keeper) DoReport(ctx sdk.Context, prover string, merkle []byte, owner st
 func (k msgServer) Report(goCtx context.Context, msg *types.MsgReport) (*types.MsgReportResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	err := k.Keeper.DoReport(ctx, msg.Prover, msg.Merkle, msg.Owner, msg.Start, msg.Creator)
+	err := k.DoReport(ctx, msg.Prover, msg.Merkle, msg.Owner, msg.Start, msg.Creator)
 	if err != nil {
 		return nil, err
 	}

--- a/x/storage/utils/trees.go
+++ b/x/storage/utils/trees.go
@@ -36,7 +36,7 @@ func BuildTree(buf io.Reader, chunkSize int64) ([]byte, []byte, [][]byte, int, e
 		hexedData := hex.EncodeToString(b)
 
 		hash := sha256.New()
-		hash.Write([]byte(fmt.Sprintf("%d%s", index, hexedData))) // appending the index and the data
+		fmt.Fprintf(hash, "%d%s", index, hexedData) // appending the index and the data
 		hashName := hash.Sum(nil)
 
 		data = append(data, hashName)


### PR DESCRIPTION
Update golangci-lint-action to v8 which uses golangci-lint >= v2.1.0
Fix new issues raised by the new version of linter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated linting workflow and configuration for improved code quality checks and formatting.
* **Refactor**
  * Simplified and streamlined internal logic in several modules for better readability and maintainability.
  * Adjusted method calls to use direct references where applicable.
  * Improved formatting and logging statements for clearer debug output.
  * Enhanced hash input handling by writing formatted strings directly to hash functions.
* **Style**
  * Modernized loop and conditional assignment syntax in select test and keeper modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->