### PR TITLE
chore: fix inconsistent function name in comment

### DIFF
--- a/x/oracle/keeper/feeds.go
+++ b/x/oracle/keeper/feeds.go
@@ -40,7 +40,7 @@ func (k Keeper) RemoveFeed(
 	))
 }
 
-// GetAllFeed returns all Feed
+// GetAllFeeds returns all Feed
 func (k Keeper) GetAllFeeds(ctx sdk.Context) (list []types.Feed) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.FeedKeyPrefix))
 	iterator := sdk.KVStorePrefixIterator(store, []byte{})

--- a/x/storage/keeper/active_deals.go
+++ b/x/storage/keeper/active_deals.go
@@ -16,7 +16,7 @@ func (k Keeper) SetLegacyActiveDeals(ctx sdk.Context, activeDeals types.LegacyAc
 	), b)
 }
 
-// GetActiveDeals returns a activeDeals from its index
+// GetLegacyActiveDeals returns a activeDeals from its index
 func (k Keeper) GetLegacyActiveDeals(
 	ctx sdk.Context,
 	cid string,
@@ -34,7 +34,7 @@ func (k Keeper) GetLegacyActiveDeals(
 	return val, true
 }
 
-// RemoveActiveDeals removes a activeDeals from the store
+// RemoveLegacyActiveDeals removes a activeDeals from the store
 func (k Keeper) RemoveLegacyActiveDeals(
 	ctx sdk.Context,
 	cid string,

--- a/x/storage/testutil/expected_keepers_mocks.go
+++ b/x/storage/testutil/expected_keepers_mocks.go
@@ -268,7 +268,7 @@ type MockRNSKeeperMockRecorder struct {
 	mock *MockRNSKeeper
 }
 
-// NewMockOracleKeeper creates a new mock instance.
+// NewMockRNSKeeper creates a new mock instance.
 func NewMockRNSKeeper(ctrl *gomock.Controller) *MockRNSKeeper {
 	mock := &MockRNSKeeper{ctrl: ctrl}
 	mock.recorder = &MockRNSKeeperMockRecorder{mock}


### PR DESCRIPTION
fix inconsistent function name in comment